### PR TITLE
Push toward switching the encoder inputs over to interrupt driven IO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,8 @@ IF (GTEST_FOUND)
 ELSE()
   MESSAGE (STATUS  "GTEST not found, skipping unit tests")
 ENDIF (GTEST_FOUND)
+  
+add_definitions( -DPC_BUILD )
 
 add_executable(firmware_sim ${FIRMWARE_SIM_SOURCES})
 target_link_libraries(firmware_sim firmware_lib )

--- a/firmware/basic_types.h
+++ b/firmware/basic_types.h
@@ -3,6 +3,8 @@
 
 #include <array>
 
+#define OCTO_ESP8266_DEBUG
+
 // Building on a PC, for test purposes.  Blank out the flag that tells the
 // compiler to put a function into ram
 #ifdef PC_BUILD

--- a/firmware/basic_types.h
+++ b/firmware/basic_types.h
@@ -3,6 +3,18 @@
 
 #include <array>
 
+// Building on a PC, for test purposes.  Blank out the flag that tells the
+// compiler to put a function into ram
+#ifdef PC_BUILD
+#define OCTO_INTERRUPT_FUNC( a ) a
+#else
+// Build target is the ESP8266.  Bring in the hardware_esp8266.h include to 
+// make sure ICACHE_RAM_ATTR is available then #define it to the flag we'll
+// use to say that a function or method has to be implemented in ram.
+#include "ESP8266WiFi.h"
+#define OCTO_INTERRUPT_FUNC( a ) a ICACHE_RAM_ATTR
+#endif
+
 namespace UrbanRobot
 {
 	const int noValue= -1;

--- a/firmware/basic_types.h
+++ b/firmware/basic_types.h
@@ -90,6 +90,7 @@ namespace UrbanRobot
     bool operator==( TypeSafeNumber rhs ) const { return num == rhs.num; };
     bool operator!=( TypeSafeNumber rhs ) const { return num != rhs.num; };
     bool operator>(TypeSafeNumber rhs ) const { return num > rhs.num; };
+    bool operator>=(TypeSafeNumber rhs ) const { return num >= rhs.num; };
     TypeSafeNumber& operator+=(TypeSafeNumber rhs ) { num += rhs.num; return *this; }
     TypeSafeNumber operator*( int rhs ) const { return TypeSafeNumber( num * rhs ); }
 

--- a/firmware/command_datasend.cpp
+++ b/firmware/command_datasend.cpp
@@ -22,8 +22,8 @@ DataSend::DataSend(
 Time::TimeUS DataSend::execute() 
 {
   if ( isOutputting ) {
-    net->get() << "ENA " << encoderA->getPosition() << "\n";  
-    net->get() << "ENB " << encoderB->getPosition() << "\n";  
+    net->get() << "ENL " << encoderA->getPosition() << " " << encoderA->getSpeed() << "\n";  
+    net->get() << "ENR " << encoderB->getPosition() << " " << encoderB->getSpeed() << "\n";  
   }
   return Time::TimeMS( 20 );  // 50 updates / second
 }

--- a/firmware/command_encoder.cpp
+++ b/firmware/command_encoder.cpp
@@ -4,19 +4,19 @@
 namespace Command{
 
 Encoder::Encoder( 
-  std::shared_ptr<HWI> hwiArg, 
+  std::shared_ptr<HW::I> hwiArg, 
   std::shared_ptr<DebugInterface> debugArg, 
   std::shared_ptr<NetInterface> netArg, 
-  HWI::Pin pin0Arg,  
-  HWI::Pin pin1Arg 
+  HW::Pin pin0Arg,  
+  HW::Pin pin1Arg 
 ) :
   hwi { hwiArg }, debug { debugArg }, net { netArg }, 
   pin0{ pin0Arg }, pin1{ pin1Arg},
   position{ 0 }
 {
   // Configure hardware pins for output
-  hwi->PinMode(pin0,  HWI::PinIOMode::M_INPUT );
-  hwi->PinMode(pin1,  HWI::PinIOMode::M_INPUT );
+  hwi->PinMode(pin0,  HW::PinIOMode::M_INPUT );
+  hwi->PinMode(pin1,  HW::PinIOMode::M_INPUT );
 
   lastGreyCode = getGreyCode();
 }
@@ -115,8 +115,8 @@ Encoder::Action Encoder::greyCodeActionTable[ 4 ][ 4 ] = {
 
 unsigned int Encoder::Encoder::getGreyCode()
 {
-  const bool pin0State = ( hwi->DigitalRead( pin0 ) == HWI::PinState::INPUT_HIGH );
-  const bool pin1State = ( hwi->DigitalRead( pin1 ) == HWI::PinState::INPUT_HIGH );
+  const bool pin0State = ( hwi->DigitalRead( pin0 ) == HW::PinState::INPUT_HIGH );
+  const bool pin1State = ( hwi->DigitalRead( pin1 ) == HW::PinState::INPUT_HIGH );
   return ( pin1State << 1 ) | pin0State;
 }
 

--- a/firmware/command_encoder.h
+++ b/firmware/command_encoder.h
@@ -53,6 +53,11 @@ class Encoder: public Base {
   ///
   int getPosition();
 
+  ///
+  /// Gets the encoder's current rotation speed
+  ///
+  int getSpeed();
+
   private:
 
   enum class Action {
@@ -83,6 +88,8 @@ class Encoder: public Base {
 
   unsigned int lastGreyCode;
   int position;
+  int speed;
+  Time::DeviceTimeUS lastStateChange;
 };
 
 }; // end Command namespace.

--- a/firmware/command_encoder.h
+++ b/firmware/command_encoder.h
@@ -28,11 +28,11 @@ class Encoder: public Base {
   /// @param[in] pin1Arg  - "pin 1" on the encoder board
   /// 
   Encoder( 
-    std::shared_ptr<HWI> hwiArg, 
+    std::shared_ptr<HW::I> hwiArg, 
     std::shared_ptr<DebugInterface> debugArg, 
     std::shared_ptr<NetInterface> netArg, 
-    HWI::Pin pin0Arg,  
-    HWI::Pin pin1Arg);
+    HW::Pin pin0Arg,  
+    HW::Pin pin1Arg);
 
   ///
   /// @brief Standard time slice function
@@ -70,16 +70,16 @@ class Encoder: public Base {
   static Action greyCodeActionTable[4][4];
 
   // @brief Interface to hardware (i.e., GPIO pins)
-  std::shared_ptr<HWI> hwi;
+  std::shared_ptr<HW::I> hwi;
   // @brief Interface to debug log
   std::shared_ptr<DebugInterface> debug;
   // @brief Interface to network (i.e., Wifi)
   std::shared_ptr<NetInterface> net;
 
   // @brief Digital input for encoder pin 0
-  const HWI::Pin pin0;
+  const HW::Pin pin0;
   // @param Digital input for encoder pin 1
-  const HWI::Pin pin1;
+  const HW::Pin pin1;
 
   unsigned int lastGreyCode;
   int position;

--- a/firmware/command_motor.cpp
+++ b/firmware/command_motor.cpp
@@ -4,11 +4,11 @@
 namespace Command{
 
 Motor::Motor( 
-  std::shared_ptr<HWI> hwiArg, 
+  std::shared_ptr<HW::I> hwiArg, 
   std::shared_ptr<DebugInterface> debugArg, 
   std::shared_ptr<NetInterface> netArg, 
-  HWI::Pin pin0Arg,  
-  HWI::Pin pin1Arg 
+  HW::Pin pin0Arg,  
+  HW::Pin pin1Arg 
 ) :
   hwi { hwiArg }, debug { debugArg }, net { netArg }, 
   pin0{ pin0Arg }, pin1{ pin1Arg},
@@ -16,8 +16,8 @@ Motor::Motor(
   lastPulse{ Pulse::NONE }
 {
   // Configure hardware pins for output
-  hwi->PinMode(pin0,  HWI::PinIOMode::M_OUTPUT );
-  hwi->PinMode(pin1,  HWI::PinIOMode::M_OUTPUT );
+  hwi->PinMode(pin0,  HW::PinIOMode::M_OUTPUT );
+  hwi->PinMode(pin1,  HW::PinIOMode::M_OUTPUT );
   // set output to "off" (both lines powered down)
   doPulse( Pulse::NONE );
 }
@@ -31,18 +31,18 @@ void Motor::doPulse( Motor::Pulse pulse )
   {
     case Pulse::FORWARD:
       // Forward, one input on, the other input off
-      hwi->DigitalWrite( pin0, HWI::PinState::MOTOR_POS );
-      hwi->DigitalWrite( pin1, HWI::PinState::MOTOR_NEG );
+      hwi->DigitalWrite( pin0, HW::PinState::MOTOR_POS );
+      hwi->DigitalWrite( pin1, HW::PinState::MOTOR_NEG );
       break;
     case Pulse::BACKWARD:
       // Backward, one input off, the other input on
-      hwi->DigitalWrite( pin0, HWI::PinState::MOTOR_NEG );
-      hwi->DigitalWrite( pin1, HWI::PinState::MOTOR_POS );
+      hwi->DigitalWrite( pin0, HW::PinState::MOTOR_NEG );
+      hwi->DigitalWrite( pin1, HW::PinState::MOTOR_POS );
       break;
     case Pulse::NONE:
       // Stopped,  Both inputs off.
-      hwi->DigitalWrite( pin0, HWI::PinState::MOTOR_NEG );
-      hwi->DigitalWrite( pin1, HWI::PinState::MOTOR_NEG );
+      hwi->DigitalWrite( pin0, HW::PinState::MOTOR_NEG );
+      hwi->DigitalWrite( pin1, HW::PinState::MOTOR_NEG );
       break;
   }
   lastPulse = pulse;

--- a/firmware/command_motor.h
+++ b/firmware/command_motor.h
@@ -25,11 +25,11 @@ class Motor: public Base {
   /// @param[in] pin1Arg  - Digital Pin that controls the other motor input
   /// 
   Motor( 
-    std::shared_ptr<HWI> hwiArg, 
+    std::shared_ptr<HW::I> hwiArg, 
     std::shared_ptr<DebugInterface> debugArg, 
     std::shared_ptr<NetInterface> netArg, 
-    HWI::Pin pin0Arg,  
-    HWI::Pin pin1Arg);
+    HW::Pin pin0Arg,  
+    HW::Pin pin1Arg);
 
   ///
   /// @brief Standard time slice function
@@ -95,15 +95,15 @@ class Motor: public Base {
   void doPulseIfChanged( Pulse pulse );
 
   // @brief Interface to hardware (i.e., GPIO pins)
-  std::shared_ptr<HWI> hwi;
+  std::shared_ptr<HW::I> hwi;
   // @brief Interface to debug log
   std::shared_ptr<DebugInterface> debug;
   // @brief Interface to network (i.e., Wifi)
   std::shared_ptr<NetInterface> net;
   // @brief Digital Pin that controls one of the motor inputs 
-  const HWI::Pin pin0;
+  const HW::Pin pin0;
   // @param Digital Pin that controls the other motor input
-  const HWI::Pin pin1;
+  const HW::Pin pin1;
 
   // @brief Current direction of the motor - forwards or backwards
   Dir dir;

--- a/firmware/command_parser.cpp
+++ b/firmware/command_parser.cpp
@@ -29,10 +29,11 @@ class CommandTemplate
 const std::vector<CommandTemplate> commandTemplates =
 {
   { "ping",       Command::Ping,          HasArg::No   },
-  { "motorl",     Command::SetMotorA,     HasArg::Yes  },
-  { "motorr",     Command::SetMotorB,     HasArg::Yes  },
-  { "encoderl",   Command::GetEncoderA,   HasArg::No   },
-  { "encoderr",   Command::GetEncoderB,   HasArg::No   },
+  { "motorl",     Command::SetMotorL,     HasArg::Yes  },
+  { "motorr",     Command::SetMotorR,     HasArg::Yes  },
+  { "motora",     Command::SetMotorA,     HasArg::Yes  },
+  { "encoderl",   Command::GetEncoderL,   HasArg::No   },
+  { "encoderr",   Command::GetEncoderR,   HasArg::No   },
   { "timems",     Command::GetTimeMs,     HasArg::No   },
   { "timeus",     Command::GetTimeUs,     HasArg::No   },
   { "profile",    Command::Profile,       HasArg::No   },

--- a/firmware/command_parser.h
+++ b/firmware/command_parser.h
@@ -14,10 +14,11 @@ namespace CommandParser {
   enum class Command {
     StartOfCommands = 0,  ///<  Start of the command list
     Ping            = 0,  ///<  Send a pong
-    SetMotorA,            ///<  Set motor A to a value
-    SetMotorB,            ///<  Set motor B to a value
-    GetEncoderA,          ///<  Get the current encoder A value
-    GetEncoderB,          ///<  Get the current encoder B value
+    SetMotorL,            ///<  Set left motor to a value
+    SetMotorR,            ///<  Set right motor to a value
+    SetMotorA,            ///<  Set both motors to a value (for debugging)
+    GetEncoderL,          ///<  Get the current left encoder value
+    GetEncoderR,          ///<  Get the current right encoder value
     GetTimeMs,            ///<  Get ms since device start
     GetTimeUs,            ///<  Get us since device start
     Profile,              ///<  Dump profiling data to net

--- a/firmware/command_process_input.cpp
+++ b/firmware/command_process_input.cpp
@@ -18,7 +18,7 @@ namespace Command {
 
 ProcessCommand::ProcessCommand(
     std::shared_ptr<NetInterface> netArg,
-    std::shared_ptr<HWI> hardwareArg,
+    std::shared_ptr<HW::I> hardwareArg,
     std::shared_ptr<DebugInterface> debugArg,
     std::shared_ptr<Time::Interface> timeArg,
     std::shared_ptr<Command::Motor> motorAArg,

--- a/firmware/command_process_input.cpp
+++ b/firmware/command_process_input.cpp
@@ -21,18 +21,18 @@ ProcessCommand::ProcessCommand(
     std::shared_ptr<HW::I> hardwareArg,
     std::shared_ptr<DebugInterface> debugArg,
     std::shared_ptr<Time::Interface> timeArg,
-    std::shared_ptr<Command::Motor> motorAArg,
-    std::shared_ptr<Command::Motor> motorBArg,
-    std::shared_ptr<Command::Encoder> encoderAArg,
-    std::shared_ptr<Command::Encoder> encoderBArg,
+    std::shared_ptr<Command::Motor> motorLArg,
+    std::shared_ptr<Command::Motor> motorRArg,
+    std::shared_ptr<Command::Encoder> encoderLArg,
+    std::shared_ptr<Command::Encoder> encoderRArg,
     std::shared_ptr<Command::SR04> sr04Arg,
     std::shared_ptr<Time::HST> hstArg,
     std::shared_ptr<Command::Scheduler> schedulerArg,
     std::shared_ptr<Command::DataSend> dataSendArg
 ) : net{ netArg }, hardware{ hardwareArg }, debugLog{ debugArg }, 
     timeMgr{ timeArg }, 
-    motorA{ motorAArg }, motorB{ motorBArg }, 
-    encoderA{ encoderAArg }, encoderB{ encoderBArg },
+    motorL{ motorLArg }, motorR{ motorRArg }, 
+    encoderL{ encoderLArg }, encoderR{ encoderRArg },
     sr04{ sr04Arg },
     hst{ hstArg },
     scheduler{ schedulerArg },
@@ -78,10 +78,11 @@ const std::unordered_map<CommandParser::Command,
   ProcessCommand::commandImpl = 
 {
   { CommandParser::Command::Ping,         &ProcessCommand::doPing},
+  { CommandParser::Command::SetMotorL,    &ProcessCommand::doSetMotorL},
+  { CommandParser::Command::SetMotorR,    &ProcessCommand::doSetMotorR},
   { CommandParser::Command::SetMotorA,    &ProcessCommand::doSetMotorA},
-  { CommandParser::Command::SetMotorB,    &ProcessCommand::doSetMotorB},
-  { CommandParser::Command::GetEncoderA,  &ProcessCommand::doGetEncoderA},
-  { CommandParser::Command::GetEncoderB,  &ProcessCommand::doGetEncoderB},
+  { CommandParser::Command::GetEncoderL,  &ProcessCommand::doGetEncoderL},
+  { CommandParser::Command::GetEncoderR,  &ProcessCommand::doGetEncoderR},
   { CommandParser::Command::GetTimeMs,    &ProcessCommand::doGetTimeMs},
   { CommandParser::Command::GetTimeUs,    &ProcessCommand::doGetTimeUs},
   { CommandParser::Command::Profile,      &ProcessCommand::doProfile},
@@ -117,30 +118,40 @@ void ProcessCommand::doError( CommandParser::CommandPacket cp )
   log << "ERROR!!!!\n";
 }
 
+void ProcessCommand::doSetMotorL( CommandParser::CommandPacket cp )
+{
+  net->get() << cp.optionalArg << "\n";
+  motorL->setSpeed( cp.optionalArg );
+}
+
+void ProcessCommand::doSetMotorR( CommandParser::CommandPacket cp )
+{
+  net->get() << cp.optionalArg << "\n";
+  motorR->setSpeed( cp.optionalArg );
+}
+
 void ProcessCommand::doSetMotorA( CommandParser::CommandPacket cp )
 {
   net->get() << cp.optionalArg << "\n";
-  motorA->setSpeed( cp.optionalArg );
+  motorL->setSpeed( cp.optionalArg );
+  // Flip the right motor so the robot goes forward or backwards
+  motorR->setSpeed( -cp.optionalArg );
 }
 
-void ProcessCommand::doSetMotorB( CommandParser::CommandPacket cp )
-{
-  net->get() << cp.optionalArg << "\n";
-  motorB->setSpeed( cp.optionalArg );
-}
-
-void ProcessCommand::doGetEncoderA( CommandParser::CommandPacket cp )
+void ProcessCommand::doGetEncoderL( CommandParser::CommandPacket cp )
 {
   (void) cp;
-  int position = encoderA->getPosition();
-  net->get() << "encodera " << position << "\n";
+  int position = encoderL->getPosition();
+  int rotation_speed = encoderL->getSpeed();
+  net->get() << "encoderl " << position << " " << rotation_speed << "\n";
 }
 
-void ProcessCommand::doGetEncoderB( CommandParser::CommandPacket cp )
+void ProcessCommand::doGetEncoderR( CommandParser::CommandPacket cp )
 {
   (void) cp;
-  int position = encoderB->getPosition();
-  net->get() << "encoderb " << position << "\n";
+  int position = encoderR->getPosition();
+  int rotation_speed = encoderR->getSpeed();
+  net->get() << "encoderr " << position << " " << rotation_speed << "\n";
 }
 
 void ProcessCommand::doGetTimeMs( CommandParser::CommandPacket cp )

--- a/firmware/command_process_input.h
+++ b/firmware/command_process_input.h
@@ -47,21 +47,24 @@ class ProcessCommand: public Base
   /// @param[in] hardwareArg  - Interface to the Hardware
   /// @param[in] debugArg     - Interface to the debug logger.
   /// @param[in] timeArg      - A simple time interfaced
-  /// @param[in] motorAArg    - The class that controls "motor a"
-  /// @param[in] motorBArg    - The class that controls "motor b"
-  /// @param[in] encoderAArg  - The encoder for "motor a"
-  /// @param[in] encoderBArg  - The encoder for "motor b"
+  /// @param[in] motorLArg    - The class that controls the left motor
+  /// @param[in] motorRArg    - The class that controls the right motor
+  /// @param[in] encoderLArg  - The encoder for left motor 
+  /// @param[in] encoderRArg  - The encoder for right motor
+  /// @param[in] sr04Arg      - The s404 sonar range finder
   /// @param[in] hstArg       - Interface for the High Speed Timer
+  /// @param[in] schedulerArg - The schedululer.  Used to display profiling
+  /// @param[in] dataSendArg  - Sends data to the host every 1/50 sec
   ///
   ProcessCommand( 
 		std::shared_ptr<NetInterface> netArg,
 		std::shared_ptr<HW::I> hardwareArg,
 		std::shared_ptr<DebugInterface> debugArg,
 		std::shared_ptr<Time::Interface> timeArg,
-		std::shared_ptr<Command::Motor> motorAArg,
-		std::shared_ptr<Command::Motor> motorBArg,
-		std::shared_ptr<Command::Encoder> encoderAArg,
-		std::shared_ptr<Command::Encoder> encoderBArg,
+		std::shared_ptr<Command::Motor> motorLArg,
+		std::shared_ptr<Command::Motor> motorRArg,
+		std::shared_ptr<Command::Encoder> encoderLArg,
+		std::shared_ptr<Command::Encoder> encoderRArg,
 		std::shared_ptr<Command::SR04> sr04Arg,
 		std::shared_ptr<Time::HST> hstArg, 
 		std::shared_ptr<Command::Scheduler > schedulerArg,
@@ -106,10 +109,11 @@ class ProcessCommand: public Base
   Time::TimeUS stateError( void );
 
   void doPing( CommandParser::CommandPacket );
+  void doSetMotorL( CommandParser::CommandPacket );
+  void doSetMotorR( CommandParser::CommandPacket );
   void doSetMotorA( CommandParser::CommandPacket );
-  void doSetMotorB( CommandParser::CommandPacket );
-  void doGetEncoderA( CommandParser::CommandPacket );
-  void doGetEncoderB( CommandParser::CommandPacket );
+  void doGetEncoderL( CommandParser::CommandPacket );
+  void doGetEncoderR( CommandParser::CommandPacket );
   void doGetTimeMs( CommandParser::CommandPacket );
   void doGetTimeUs( CommandParser::CommandPacket );
   void doProfile( CommandParser::CommandPacket );
@@ -123,14 +127,14 @@ class ProcessCommand: public Base
   std::shared_ptr<DebugInterface> debugLog;
   std::shared_ptr<Time::Interface> timeMgr;
   
-  /// @brief Interface to Motor A
-  std::shared_ptr<Command::Motor> motorA;
-  /// @brief Interface to Motor B
-  std::shared_ptr<Command::Motor> motorB;
-  /// @brief Interface to Encoder A
-  std::shared_ptr<Command::Encoder> encoderA;
-  /// @brief Interface to Encoder B
-  std::shared_ptr<Command::Encoder> encoderB;
+  /// @brief Interface to the Left Motor 
+  std::shared_ptr<Command::Motor> motorL;
+  /// @brief Interface to the Right Motor 
+  std::shared_ptr<Command::Motor> motorR;
+  /// @brief Interface to the Left Encoder 
+  std::shared_ptr<Command::Encoder> encoderL;
+  /// @brief Interface to the Right Encoder
+  std::shared_ptr<Command::Encoder> encoderR;
   /// @brief Interface to SR04 Sonar Range Finder
   std::shared_ptr<Command::SR04> sr04;
   /// @brief Interface to the high speed timer

--- a/firmware/command_process_input.h
+++ b/firmware/command_process_input.h
@@ -55,7 +55,7 @@ class ProcessCommand: public Base
   ///
   ProcessCommand( 
 		std::shared_ptr<NetInterface> netArg,
-		std::shared_ptr<HWI> hardwareArg,
+		std::shared_ptr<HW::I> hardwareArg,
 		std::shared_ptr<DebugInterface> debugArg,
 		std::shared_ptr<Time::Interface> timeArg,
 		std::shared_ptr<Command::Motor> motorAArg,
@@ -119,7 +119,7 @@ class ProcessCommand: public Base
   void doError( CommandParser::CommandPacket );
 
   std::shared_ptr<NetInterface> net;
-  std::shared_ptr<HWI> hardware;
+  std::shared_ptr<HW::I> hardware;
   std::shared_ptr<DebugInterface> debugLog;
   std::shared_ptr<Time::Interface> timeMgr;
   

--- a/firmware/command_scheduler.cpp
+++ b/firmware/command_scheduler.cpp
@@ -4,7 +4,7 @@ namespace Command {
 
 Scheduler::Scheduler(
     std::shared_ptr<NetInterface> netArg,
-    std::shared_ptr<HWI> hardwareArg,
+    std::shared_ptr<HW::I> hardwareArg,
     std::shared_ptr<DebugInterface> debugArg,
     std::shared_ptr<Time::HST> hstArg ) :
     net{ netArg },

--- a/firmware/command_scheduler.h
+++ b/firmware/command_scheduler.h
@@ -24,7 +24,7 @@ class Scheduler: Base {
 
   Scheduler(
     std::shared_ptr<NetInterface> netArg,
-    std::shared_ptr<HWI> hardwareArg,
+    std::shared_ptr<HW::I> hardwareArg,
     std::shared_ptr<DebugInterface> debugArg,
     std::shared_ptr<Time::HST> hstArg );
 
@@ -45,7 +45,7 @@ class Scheduler: Base {
   using PriorityAndCommandSlot = std::pair<Time::DeviceTimeUS, CommandSlotIndex >;
 
   std::shared_ptr<NetInterface> net;
-  std::shared_ptr<HWI> hardware;
+  std::shared_ptr<HW::I> hardware;
   std::shared_ptr<DebugInterface> debug;
   std::shared_ptr<Time::HST > hst;
 

--- a/firmware/command_sr04.cpp
+++ b/firmware/command_sr04.cpp
@@ -27,9 +27,11 @@ SR04::SR04(
   distance{ READING_FAILED }
 {
   // Configure hardware pins for output
+#ifndef OCTO_ESP8266_DEBUG
   hwi->PinMode(pinTrig,  HW::PinIOMode::M_OUTPUT );
   hwi->PinMode(pinEcho,  HW::PinIOMode::M_INPUT );
   hwi->DigitalWrite( pinTrig, HW::PinState::ECHO_OFF );
+#endif
 }
 
 

--- a/firmware/command_sr04.cpp
+++ b/firmware/command_sr04.cpp
@@ -13,12 +13,12 @@ const Time::TimeUS idleReschedule{ 10000 };
 const Time::TimeUS activeReschedule{ 20 };
 
 SR04::SR04( 
-  std::shared_ptr<HWI> hwiArg, 
+  std::shared_ptr<HW::I> hwiArg, 
   std::shared_ptr<DebugInterface> debugArg, 
   std::shared_ptr<NetInterface> netArg, 
   std::shared_ptr<Time::HST> hstArg, 
-  HWI::Pin pinTrigArg,  
-  HWI::Pin pinEchoArg 
+  HW::Pin pinTrigArg,  
+  HW::Pin pinEchoArg 
 ) :
   hwi { hwiArg }, debug { debugArg }, net { netArg }, 
   hst{ hstArg },
@@ -27,9 +27,9 @@ SR04::SR04(
   distance{ READING_FAILED }
 {
   // Configure hardware pins for output
-  hwi->PinMode(pinTrig,  HWI::PinIOMode::M_OUTPUT );
-  hwi->PinMode(pinEcho,  HWI::PinIOMode::M_INPUT );
-  hwi->DigitalWrite( pinTrig, HWI::PinState::ECHO_OFF );
+  hwi->PinMode(pinTrig,  HW::PinIOMode::M_OUTPUT );
+  hwi->PinMode(pinEcho,  HW::PinIOMode::M_INPUT );
+  hwi->DigitalWrite( pinTrig, HW::PinState::ECHO_OFF );
 }
 
 
@@ -46,7 +46,7 @@ void SR04::handleAwaitingEcho()
     return;
   }
 
-  if ( hwi->DigitalRead( pinEcho ) == HWI::PinState::INPUT_LOW )
+  if ( hwi->DigitalRead( pinEcho ) == HW::PinState::INPUT_LOW )
   {
     //
     // The pulse came in sometime between now and the last time we checked
@@ -77,18 +77,18 @@ void SR04::handleAwaitingEcho()
 
 void SR04::handleSensorRequested()
 {
-  hwi->DigitalWrite( pinTrig, HWI::PinState::ECHO_OFF );
+  hwi->DigitalWrite( pinTrig, HW::PinState::ECHO_OFF );
   auto start = hst->usSinceDeviceStart();
   while (hst->usSinceDeviceStart() - start < 3 );
 
-  hwi->DigitalWrite( pinTrig, HWI::PinState::ECHO_ON );
+  hwi->DigitalWrite( pinTrig, HW::PinState::ECHO_ON );
   start = hst->usSinceDeviceStart();
   while (hst->usSinceDeviceStart() - start < 11 );
 
-  hwi->DigitalWrite( pinTrig, HWI::PinState::ECHO_OFF );
+  hwi->DigitalWrite( pinTrig, HW::PinState::ECHO_OFF );
 
   start = hst->usSinceDeviceStart();
-  while( hwi->DigitalRead( pinEcho ) == HWI::PinState::INPUT_LOW ) 
+  while( hwi->DigitalRead( pinEcho ) == HW::PinState::INPUT_LOW ) 
   {
     // It looks like it takes about 500us to get a pulse out.
     if ( hst->usSinceDeviceStart() - start > 1000 ) 

--- a/firmware/command_sr04.h
+++ b/firmware/command_sr04.h
@@ -53,12 +53,12 @@ class SR04: public Base {
   /// @param[in] pinEchoArg - "Echo" input on the sensor
   /// 
   SR04( 
-    std::shared_ptr<HWI> hwiArg, 
+    std::shared_ptr<HW::I> hwiArg, 
     std::shared_ptr<DebugInterface> debugArg, 
     std::shared_ptr<NetInterface> netArg, 
     std::shared_ptr<Time::HST> hstArg,
-    HWI::Pin pinTrigArg,  
-    HWI::Pin pinEchoArg);
+    HW::Pin pinTrigArg,  
+    HW::Pin pinEchoArg);
 
   ///
   /// @brief Standard time slice function
@@ -93,7 +93,7 @@ class SR04: public Base {
   };
 
   // @brief Interface to hardware (i.e., GPIO pins)
-  std::shared_ptr<HWI> hwi;
+  std::shared_ptr<HW::I> hwi;
   // @brief Interface to debug log
   std::shared_ptr<DebugInterface> debug;
   // @brief Interface to network (i.e., Wifi)
@@ -102,9 +102,9 @@ class SR04: public Base {
   std::shared_ptr<Time::HST > hst;
 
   // @brief Digital output to trigger a sound pulse
-  const HWI::Pin pinTrig;
+  const HW::Pin pinTrig;
   // @param Digital input to listen for the echo on
-  const HWI::Pin pinEcho;
+  const HW::Pin pinEcho;
 
   Mode mode;
   Time::DeviceTimeUS echoSentAt;

--- a/firmware/debug_esp8266.cpp
+++ b/firmware/debug_esp8266.cpp
@@ -1,10 +1,15 @@
 #include <ESP8266WiFi.h>
+#include "basic_types.h"
 #include "debug_esp8266.h"
 
 DebugESP8266::DebugESP8266()
 {
-	//Serial.begin( 115200 );
+#ifdef OCTO_ESP8266_DEBUG
+	Serial.begin( 115200 );
+  isDisabled = false;
+#else
   isDisabled = true;
+#endif
 }
 
 void DebugESP8266::disable()

--- a/firmware/hardware_esp8266.cpp
+++ b/firmware/hardware_esp8266.cpp
@@ -117,8 +117,10 @@ HardwareESP8266::HardwareESP8266( std::shared_ptr< Time::HST> hst )
     fastAbstractToRealPinState[ index ] = entry.second;
   }
 
+#ifndef OCTO_ESP8266_DEBUG
   pinMode( 1, FUNCTION_3 );
   pinMode( 3, FUNCTION_3 );
+#endif
 
   for ( size_t index = 0; index < static_cast<size_t>(HW::Pin::END_OF_PINS); ++index ) {
     pinToInputHandlerRaw[ index ] = nullptr;

--- a/firmware/hardware_esp8266.cpp
+++ b/firmware/hardware_esp8266.cpp
@@ -76,14 +76,29 @@ std::array<std::unique_ptr<InputInterruptHandler>, static_cast<size_t>(HW::Pin::
 // 
 InputInterruptHandler* pinToInputHandlerRaw[ static_cast<size_t>(HW::Pin::END_OF_PINS) ];
 
-//
-// TODO - enable interrupts and add for each encoder type
-// 
-//void ICACHE_RAM_ATTR leftEncoderPin0Int()
-//{
-//  InputInterruptHandler* handler = pinToInputHandlerRaw[ static_cast<size_t>(HW::Pin::ENCODER0_PIN0) ];
-//  handler->interrupt();
-//}
+void ICACHE_RAM_ATTR leftEncoderPin0Int()
+{
+  InputInterruptHandler* handler = pinToInputHandlerRaw[ static_cast<size_t>(HW::Pin::ENCODER0_PIN0) ];
+  handler->interrupt();
+}
+
+void ICACHE_RAM_ATTR leftEncoderPin1Int()
+{
+  InputInterruptHandler* handler = pinToInputHandlerRaw[ static_cast<size_t>(HW::Pin::ENCODER0_PIN1) ];
+  handler->interrupt();
+}
+
+void ICACHE_RAM_ATTR rightEncoderPin0Int()
+{
+  InputInterruptHandler* handler = pinToInputHandlerRaw[ static_cast<size_t>(HW::Pin::ENCODER1_PIN0) ];
+  handler->interrupt();
+}
+
+void ICACHE_RAM_ATTR rightEncoderPin1Int()
+{
+  InputInterruptHandler* handler = pinToInputHandlerRaw[ static_cast<size_t>(HW::Pin::ENCODER1_PIN1) ];
+  handler->interrupt();
+}
 
 } // end anonymous namespace
 
@@ -131,6 +146,16 @@ HardwareESP8266::HardwareESP8266( std::shared_ptr< Time::HST> hst )
     pinToInputHandler[ slot ] = std::unique_ptr<InputInterruptHandler>( new InputInterruptHandler(hst, interruptInput ));
     pinToInputHandlerRaw[ slot ] = pinToInputHandler[ slot ].get();
   }
+
+  pinMode( pinMap.at( Pin::ENCODER0_PIN0 ), INPUT );
+  pinMode( pinMap.at( Pin::ENCODER1_PIN0 ), INPUT );
+  pinMode( pinMap.at( Pin::ENCODER0_PIN1 ), INPUT );
+  pinMode( pinMap.at( Pin::ENCODER1_PIN1 ), INPUT );
+
+  attachInterrupt( digitalPinToInterrupt( pinMap.at( Pin::ENCODER0_PIN0 ) ), leftEncoderPin0Int, CHANGE );
+  attachInterrupt( digitalPinToInterrupt( pinMap.at( Pin::ENCODER0_PIN1 ) ), leftEncoderPin1Int, CHANGE );
+  attachInterrupt( digitalPinToInterrupt( pinMap.at( Pin::ENCODER1_PIN0 ) ), rightEncoderPin0Int, CHANGE );
+  attachInterrupt( digitalPinToInterrupt( pinMap.at( Pin::ENCODER1_PIN1 ) ), rightEncoderPin1Int, CHANGE );
 }
 
 void HardwareESP8266::DigitalWrite( Pin pin, PinState state )
@@ -164,8 +189,8 @@ IEvent& HardwareESP8266::GetInputEvents( Pin pin )
   auto& handler = pinToInputHandler[ static_cast<size_t>( pin ) ];
 
   // Fake an interrupt for now
-  InputInterruptHandler* rawHandler = pinToInputHandlerRaw[ static_cast<size_t>(pin ) ];
-  rawHandler->interrupt();
+  //InputInterruptHandler* rawHandler = pinToInputHandlerRaw[ static_cast<size_t>(pin ) ];
+  //rawHandler->interrupt();
 
   return handler->getEvents();
 }

--- a/firmware/hardware_esp8266.cpp
+++ b/firmware/hardware_esp8266.cpp
@@ -1,7 +1,7 @@
 #include <ESP8266WiFi.h>
 #include "hardware_esp8266.h"
 
-const std::unordered_map<HWI::Pin, int, EnumHash > HardwareESP8266::pinMap = 
+const std::unordered_map<HW::Pin, int, EnumHash > HardwareESP8266::pinMap = 
 {
   { Pin::MOTOR0_PIN0,     0     },
   { Pin::MOTOR0_PIN1,     2     },
@@ -15,7 +15,7 @@ const std::unordered_map<HWI::Pin, int, EnumHash > HardwareESP8266::pinMap =
   { Pin::SR04_ECHO,       5     }
 };
 
-const std::unordered_map<HWI::PinState, int, EnumHash > HardwareESP8266::pinStateMap = {
+const std::unordered_map<HW::PinState, int, EnumHash > HardwareESP8266::pinStateMap = {
   { PinState::MOTOR_POS,      HIGH  },
   { PinState::MOTOR_NEG,      LOW   },
   { PinState::ECHO_ON,        HIGH  },
@@ -24,8 +24,8 @@ const std::unordered_map<HWI::PinState, int, EnumHash > HardwareESP8266::pinStat
 
 namespace
 {
-  std::array<int, static_cast<size_t>(HWI::Pin::END_OF_PINS)  > fastAbstractToRealPin;
-  std::array<int, static_cast<size_t>(HWI::PinState::END_OF_PIN_STATES) > fastAbstractToRealPinState; 
+  std::array<int, static_cast<size_t>(HW::Pin::END_OF_PINS)  > fastAbstractToRealPin;
+  std::array<int, static_cast<size_t>(HW::PinState::END_OF_PIN_STATES) > fastAbstractToRealPinState; 
 } // end anonymous namespace
 
 HardwareESP8266::HardwareESP8266()
@@ -74,7 +74,7 @@ void HardwareESP8266::PinMode( Pin pin, PinIOMode mode )
   pinMode( actualPin, mode == PinIOMode::M_OUTPUT ? OUTPUT : INPUT );
 }
 
-HWI::PinState HardwareESP8266::DigitalRead( Pin pin)
+HW::PinState HardwareESP8266::DigitalRead( Pin pin)
 {
   const int actualPin = fastAbstractToRealPin[ static_cast<size_t>( pin ) ];
   const int actualState = digitalRead( actualPin );

--- a/firmware/hardware_esp8266.h
+++ b/firmware/hardware_esp8266.h
@@ -3,7 +3,8 @@
 
 #include "hardware_interface.h"
 
-class HardwareESP8266: public HWI
+namespace HW {
+class HardwareESP8266: public I
 {
   public:
 
@@ -19,6 +20,7 @@ class HardwareESP8266: public HWI
  
   static const std::unordered_map<HWI::Pin, int, EnumHash > pinMap;
   static const std::unordered_map<HWI::PinState, int, EnumHash > pinStateMap;
+};
 };
 
 #endif

--- a/firmware/hardware_esp8266.h
+++ b/firmware/hardware_esp8266.h
@@ -2,24 +2,21 @@
 #define __HARDWARE_ARDUINO_H__
 
 #include "hardware_interface.h"
+#include "time_hst.h"
 
 namespace HW {
 class HardwareESP8266: public I
 {
   public:
 
-  HardwareESP8266();
+  HardwareESP8266( std::shared_ptr< Time::HST> hstArg );
   virtual ~HardwareESP8266() {}
 
   void     DigitalWrite( Pin pin, PinState state ) override;
   void     PinMode( Pin pin, PinIOMode state ) override;
   PinState DigitalRead( Pin pin) override;
   unsigned AnalogRead( Pin pin) override;
-
-  private:
- 
-  static const std::unordered_map<HWI::Pin, int, EnumHash > pinMap;
-  static const std::unordered_map<HWI::PinState, int, EnumHash > pinStateMap;
+  IEvent& GetInputEvents( Pin pin) override;
 };
 };
 

--- a/firmware/hardware_interface.cpp
+++ b/firmware/hardware_interface.cpp
@@ -1,6 +1,8 @@
 #include "hardware_interface.h"
 
-const std::unordered_map<HWI::Pin,std::string,EnumHash> HWI::pinNames = {
+namespace HW {
+
+const std::unordered_map<Pin,std::string,EnumHash> pinNames = {
     { Pin::MOTOR0_PIN0,     "Motor0 Pin0" },
     { Pin::MOTOR0_PIN1,     "Motor0 Pin1" },
     { Pin::MOTOR1_PIN0,     "Motor1 Pin0" },
@@ -13,7 +15,7 @@ const std::unordered_map<HWI::Pin,std::string,EnumHash> HWI::pinNames = {
     { Pin::SR04_ECHO,       "SR04 Echo" },
 };
 
-const std::unordered_map<HWI::PinState,std::string,EnumHash> HWI::pinStateNames = {
+const std::unordered_map<PinState,std::string,EnumHash> pinStateNames = {
   { PinState::MOTOR_POS,            "Voltage On"      },
   { PinState::MOTOR_NEG,            "Voltage Off"     },
   { PinState::INPUT_LOW,            "Input GND"       },
@@ -22,8 +24,10 @@ const std::unordered_map<HWI::PinState,std::string,EnumHash> HWI::pinStateNames 
   { PinState::ECHO_ON,              "SR04 Echo Pulse" }
 };
 
-const std::unordered_map<HWI::PinIOMode,std::string,EnumHash> HWI::pinIOModeNames = {
+const std::unordered_map<PinIOMode,std::string,EnumHash> pinIOModeNames = {
     { PinIOMode::M_INPUT,        "Input" },
     { PinIOMode::M_OUTPUT,       "Output" }
 };
+
+}; // end namespace HW
 

--- a/firmware/hardware_interface.h
+++ b/firmware/hardware_interface.h
@@ -4,57 +4,9 @@
 #include <unordered_map>
 #include <string>
 #include "basic_types.h"
-
-struct EnumHash
-{
-  // @brief Type convert any enum type to a size_t for hashing
-  template <class T>
-  std::size_t operator()(T enum_val) const
-  {
-    return static_cast<std::size_t>(enum_val);
-  }
-};
+#include "hardware_types.h"   // pin enums & related functions
 
 namespace HW {
-
-enum class Pin {
-  START_OF_PINS = 0,
-  MOTOR0_PIN0 = 0,
-  MOTOR0_PIN1,
-  MOTOR1_PIN0,
-  MOTOR1_PIN1,
-  ENCODER0_PIN0,
-  ENCODER0_PIN1,
-  ENCODER1_PIN0,
-  ENCODER1_PIN1,
-  SR04_TRIG,
-  SR04_ECHO,
-  END_OF_PINS 
-};
-
-enum class PinState {
-  START_OF_PIN_STATES = 0,
-  MOTOR_POS = 0,    // Apply voltage to pin
-  MOTOR_NEG,        // Don't apply voltage
-  INPUT_LOW,        // Some input is 0            
-  INPUT_HIGH,       // Some input is 1
-  ECHO_OFF,         // sr04 echo is disabled
-  ECHO_ON,          // sr04 echo is pulsing
-  END_OF_PIN_STATES
-};
-
-// Arduino.h uses #define to redefine OUTPUT and INPUT,  so use
-//           M_OUTPUT and M_INPUT here.
-enum class PinIOMode {
-  START_OF_PIN_IO_MODES = 0,
-  M_OUTPUT = 0,
-  M_INPUT = 1,
-  END_OF_IO_MODES
-};
-
-extern const std::unordered_map<Pin,std::string,EnumHash> pinNames;
-extern const std::unordered_map<PinState,std::string,EnumHash> pinStateNames;
-extern const std::unordered_map<PinIOMode,std::string,EnumHash> pinIOModeNames;
 
 /// @brief Interface to the hardware
 class I
@@ -69,36 +21,6 @@ class I
   virtual PinState DigitalRead( Pin pin) = 0;
 };
 };  // End HW namespace
-
-// @brief Increment operator for Hardware Interface Pin
-//
-// @param[in] pin - The pin to increment. 
-// @return - The next value in the Enum.
-//
-inline HW::Pin& operator++( HW::Pin &pin ) 
-{
-  return UrbanRobot::advance< HW::Pin, HW::Pin::END_OF_PINS >( pin );
-}
-
-// @brief Increment operator for Hardware Interface Pin State
-//
-// @param[in] pinState - The pin state to increment. 
-// @return - The next value in the Enum.
-// 
-inline HW::PinState& operator++( HW::PinState &pin ) 
-{
-  return UrbanRobot::advance< HW::PinState, HW::PinState::END_OF_PIN_STATES >( pin );
-}
-
-// @brief Increment operator for Hardware Interface Pin IO Mode
-//
-// @param[in] pinIoMode - The pin IO Mode to increment. 
-// @return - The next value in the Enum.
-// 
-inline HW::PinIOMode& operator++( HW::PinIOMode &pin ) 
-{
-  return UrbanRobot::advance< HW::PinIOMode, HW::PinIOMode::END_OF_IO_MODES >( pin );
-}
 
 #endif
 

--- a/firmware/hardware_interface.h
+++ b/firmware/hardware_interface.h
@@ -15,65 +15,69 @@ struct EnumHash
   }
 };
 
-class HWI
+namespace HW {
+
+enum class Pin {
+  START_OF_PINS = 0,
+  MOTOR0_PIN0 = 0,
+  MOTOR0_PIN1,
+  MOTOR1_PIN0,
+  MOTOR1_PIN1,
+  ENCODER0_PIN0,
+  ENCODER0_PIN1,
+  ENCODER1_PIN0,
+  ENCODER1_PIN1,
+  SR04_TRIG,
+  SR04_ECHO,
+  END_OF_PINS 
+};
+
+enum class PinState {
+  START_OF_PIN_STATES = 0,
+  MOTOR_POS = 0,    // Apply voltage to pin
+  MOTOR_NEG,        // Don't apply voltage
+  INPUT_LOW,        // Some input is 0            
+  INPUT_HIGH,       // Some input is 1
+  ECHO_OFF,         // sr04 echo is disabled
+  ECHO_ON,          // sr04 echo is pulsing
+  END_OF_PIN_STATES
+};
+
+// Arduino.h uses #define to redefine OUTPUT and INPUT,  so use
+//           M_OUTPUT and M_INPUT here.
+enum class PinIOMode {
+  START_OF_PIN_IO_MODES = 0,
+  M_OUTPUT = 0,
+  M_INPUT = 1,
+  END_OF_IO_MODES
+};
+
+extern const std::unordered_map<Pin,std::string,EnumHash> pinNames;
+extern const std::unordered_map<PinState,std::string,EnumHash> pinStateNames;
+extern const std::unordered_map<PinIOMode,std::string,EnumHash> pinIOModeNames;
+
+/// @brief Interface to the hardware
+class I
 {
   public:
 
-  virtual ~HWI() {}
-
-  enum class Pin {
-    START_OF_PINS = 0,
-    MOTOR0_PIN0 = 0,
-    MOTOR0_PIN1,
-    MOTOR1_PIN0,
-    MOTOR1_PIN1,
-    ENCODER0_PIN0,
-    ENCODER0_PIN1,
-    ENCODER1_PIN0,
-    ENCODER1_PIN1,
-    SR04_TRIG,
-    SR04_ECHO,
-    END_OF_PINS 
-  };
-
-  enum class PinState {
-    START_OF_PIN_STATES = 0,
-    MOTOR_POS = 0,    // Apply voltage to pin
-    MOTOR_NEG,        // Don't apply voltage
-    INPUT_LOW,        // Some input is 0            
-    INPUT_HIGH,       // Some input is 1
-    ECHO_OFF,         // sr04 echo is disabled
-    ECHO_ON,          // sr04 echo is pulsing
-    END_OF_PIN_STATES
-  };
-
-  // Arduino.h uses #define to redefine OUTPUT and INPUT,  so use
-  //           M_OUTPUT and M_INPUT here.  Thanks Obama.
-  enum class PinIOMode {
-    START_OF_PIN_IO_MODES = 0,
-    M_OUTPUT = 0,
-    M_INPUT = 1,
-    END_OF_IO_MODES
-  };
-
-  const static std::unordered_map<Pin,std::string,EnumHash> pinNames;
-  const static std::unordered_map<PinState,std::string,EnumHash> pinStateNames;
-  const static std::unordered_map<PinIOMode,std::string,EnumHash> pinIOModeNames;
+  virtual ~I() {}
 
   virtual void DigitalWrite( Pin pin, PinState state ) = 0;
   virtual void PinMode( Pin pin, PinIOMode mode ) = 0;
   virtual unsigned AnalogRead( Pin pin ) = 0;
   virtual PinState DigitalRead( Pin pin) = 0;
 };
+};  // End HW namespace
 
 // @brief Increment operator for Hardware Interface Pin
 //
 // @param[in] pin - The pin to increment. 
 // @return - The next value in the Enum.
 //
-inline HWI::Pin& operator++( HWI::Pin &pin ) 
+inline HW::Pin& operator++( HW::Pin &pin ) 
 {
-  return UrbanRobot::advance< HWI::Pin, HWI::Pin::END_OF_PINS >( pin );
+  return UrbanRobot::advance< HW::Pin, HW::Pin::END_OF_PINS >( pin );
 }
 
 // @brief Increment operator for Hardware Interface Pin State
@@ -81,9 +85,9 @@ inline HWI::Pin& operator++( HWI::Pin &pin )
 // @param[in] pinState - The pin state to increment. 
 // @return - The next value in the Enum.
 // 
-inline HWI::PinState& operator++( HWI::PinState &pin ) 
+inline HW::PinState& operator++( HW::PinState &pin ) 
 {
-  return UrbanRobot::advance< HWI::PinState, HWI::PinState::END_OF_PIN_STATES >( pin );
+  return UrbanRobot::advance< HW::PinState, HW::PinState::END_OF_PIN_STATES >( pin );
 }
 
 // @brief Increment operator for Hardware Interface Pin IO Mode
@@ -91,9 +95,9 @@ inline HWI::PinState& operator++( HWI::PinState &pin )
 // @param[in] pinIoMode - The pin IO Mode to increment. 
 // @return - The next value in the Enum.
 // 
-inline HWI::PinIOMode& operator++( HWI::PinIOMode &pin ) 
+inline HW::PinIOMode& operator++( HW::PinIOMode &pin ) 
 {
-  return UrbanRobot::advance< HWI::PinIOMode, HWI::PinIOMode::END_OF_IO_MODES >( pin );
+  return UrbanRobot::advance< HW::PinIOMode, HW::PinIOMode::END_OF_IO_MODES >( pin );
 }
 
 #endif

--- a/firmware/hardware_interface.h
+++ b/firmware/hardware_interface.h
@@ -4,9 +4,21 @@
 #include <unordered_map>
 #include <string>
 #include "basic_types.h"
-#include "hardware_types.h"   // pin enums & related functions
+#include "hardware_types.h"     // pin enums & related functions
+#include "util_ipinevents.h"    // for the IPinEvent interface 
 
 namespace HW {
+
+//
+// Start with a 64 event buffer.  That should be overkill unless the encoder
+// bounces and generates a pile of events.  
+//
+// If that does seem to happen, maybe the interrupt routine can detect the 
+// fact that the pin is changing quickly and just over-write the top entry
+// in the pipe.  I'd prefer to not have to deal with that inside the interrupt
+// route if possible.
+//
+using IEvent = Util::IPinEvents<64>;
 
 /// @brief Interface to the hardware
 class I
@@ -19,6 +31,7 @@ class I
   virtual void PinMode( Pin pin, PinIOMode mode ) = 0;
   virtual unsigned AnalogRead( Pin pin ) = 0;
   virtual PinState DigitalRead( Pin pin) = 0;
+  virtual IEvent& GetInputEvents( Pin pin ) = 0;
 };
 };  // End HW namespace
 

--- a/firmware/hardware_types.h
+++ b/firmware/hardware_types.h
@@ -1,6 +1,9 @@
 #ifndef __HARDWARE_TYPES_H__
 #define __HARDWARE_TYPES_H__
 
+#include <unordered_map>
+#include "basic_types.h"      // For UrbanRobot::advance
+
 /// @brief Lightweight type class for hardware.
 ///
 /// Examples:  Pin Enums, functions that manipulate the same

--- a/firmware/hardware_types.h
+++ b/firmware/hardware_types.h
@@ -1,0 +1,93 @@
+#ifndef __HARDWARE_TYPES_H__
+#define __HARDWARE_TYPES_H__
+
+/// @brief Lightweight type class for hardware.
+///
+/// Examples:  Pin Enums, functions that manipulate the same
+///
+
+struct EnumHash
+{
+  // @brief Type convert any enum type to a size_t for hashing
+  template <class T>
+  std::size_t operator()(T enum_val) const
+  {
+    return static_cast<std::size_t>(enum_val);
+  }
+};
+
+namespace HW {
+
+enum class Pin {
+  START_OF_PINS = 0,
+  MOTOR0_PIN0 = 0,
+  MOTOR0_PIN1,
+  MOTOR1_PIN0,
+  MOTOR1_PIN1,
+  ENCODER0_PIN0,
+  ENCODER0_PIN1,
+  ENCODER1_PIN0,
+  ENCODER1_PIN1,
+  SR04_TRIG,
+  SR04_ECHO,
+  END_OF_PINS 
+};
+
+enum class PinState {
+  START_OF_PIN_STATES = 0,
+  MOTOR_POS = 0,    // Apply voltage to pin
+  MOTOR_NEG,        // Don't apply voltage
+  INPUT_LOW,        // Some input is 0            
+  INPUT_HIGH,       // Some input is 1
+  ECHO_OFF,         // sr04 echo is disabled
+  ECHO_ON,          // sr04 echo is pulsing
+  END_OF_PIN_STATES
+};
+
+// Arduino.h uses #define to redefine OUTPUT and INPUT,  so use
+//           M_OUTPUT and M_INPUT here.
+enum class PinIOMode {
+  START_OF_PIN_IO_MODES = 0,
+  M_OUTPUT = 0,
+  M_INPUT = 1,
+  END_OF_IO_MODES
+};
+
+extern const std::unordered_map<Pin,std::string,EnumHash> pinNames;
+extern const std::unordered_map<PinState,std::string,EnumHash> pinStateNames;
+extern const std::unordered_map<PinIOMode,std::string,EnumHash> pinIOModeNames;
+
+}; // end HW namespace
+
+// @brief Increment operator for Hardware Interface Pin
+//
+// @param[in] pin - The pin to increment. 
+// @return - The next value in the Enum.
+//
+inline HW::Pin& operator++( HW::Pin &pin ) 
+{
+  return UrbanRobot::advance< HW::Pin, HW::Pin::END_OF_PINS >( pin );
+}
+
+// @brief Increment operator for Hardware Interface Pin State
+//
+// @param[in] pinState - The pin state to increment. 
+// @return - The next value in the Enum.
+// 
+inline HW::PinState& operator++( HW::PinState &pin ) 
+{
+  return UrbanRobot::advance< HW::PinState, HW::PinState::END_OF_PIN_STATES >( pin );
+}
+
+// @brief Increment operator for Hardware Interface Pin IO Mode
+//
+// @param[in] pinIoMode - The pin IO Mode to increment. 
+// @return - The next value in the Enum.
+// 
+inline HW::PinIOMode& operator++( HW::PinIOMode &pin ) 
+{
+  return UrbanRobot::advance< HW::PinIOMode, HW::PinIOMode::END_OF_IO_MODES >( pin );
+}
+
+#endif
+

--- a/firmware/main.cpp
+++ b/firmware/main.cpp
@@ -35,19 +35,19 @@ void setup() {
   auto time      = std::make_shared<Time::Manager>( timeNNTP, hst );
   auto motorA = std::make_shared<Command::Motor>(
                         hardware, debug, wifi, 
-                        HWI::Pin::MOTOR0_PIN0, HWI::Pin::MOTOR0_PIN1 );
+                        HW::Pin::MOTOR0_PIN0, HW::Pin::MOTOR0_PIN1 );
   auto motorB = std::make_shared<Command::Motor>(
                         hardware, debug, wifi, 
-                        HWI::Pin::MOTOR1_PIN0, HWI::Pin::MOTOR1_PIN1 );
+                        HW::Pin::MOTOR1_PIN0, HW::Pin::MOTOR1_PIN1 );
   auto encoderA = std::make_shared<Command::Encoder>(
                         hardware, debug, wifi, 
-                        HWI::Pin::ENCODER0_PIN0, HWI::Pin::ENCODER0_PIN1 );
+                        HW::Pin::ENCODER0_PIN0, HW::Pin::ENCODER0_PIN1 );
   auto encoderB = std::make_shared<Command::Encoder>(
                         hardware, debug, wifi, 
-                        HWI::Pin::ENCODER1_PIN0, HWI::Pin::ENCODER1_PIN1 );
+                        HW::Pin::ENCODER1_PIN0, HW::Pin::ENCODER1_PIN1 );
   auto sr04     = std::make_shared<Command::SR04> ( 
                         hardware, debug, wifi, hst,
-                        HWI::Pin::SR04_TRIG, HWI::Pin::SR04_ECHO );
+                        HW::Pin::SR04_TRIG, HW::Pin::SR04_ECHO );
           
   auto dataSend = std::make_shared<Command::DataSend>( debug, wifi, 
                         encoderA, encoderB );

--- a/firmware/main.cpp
+++ b/firmware/main.cpp
@@ -67,7 +67,9 @@ void setup() {
   scheduler->addCommand( motorB );
   scheduler->addCommand( encoderA );
   scheduler->addCommand( encoderB );
+#ifndef OCTO_ESP8266_DEBUG
   scheduler->addCommand( sr04 );
+#endif
   scheduler->addCommand( wifi );
   auto connection = wifi->getShared();
   scheduler->addCommand( connection );

--- a/firmware/main.cpp
+++ b/firmware/main.cpp
@@ -27,8 +27,8 @@ void loop() {
 void setup() {
   auto debug     = std::make_shared<DebugESP8266>();
   auto wifi      = std::make_shared<WifiInterfaceEthernet>(debug);
-  auto hardware  = std::make_shared<HardwareESP8266>();
   auto hst       = std::make_shared<Time::ESP8266_HST>();
+  auto hardware  = std::make_shared<HW::HardwareESP8266>( hst );
   scheduler      = std::make_shared<Command::Scheduler>( 
                         wifi, hardware, debug, hst );
   auto timeNNTP  = std::make_shared<TimeESP8266>( debug );

--- a/firmware/time_esp8266hst.cpp
+++ b/firmware/time_esp8266hst.cpp
@@ -1,19 +1,6 @@
 #include <Arduino.h>
 #include "time_esp8266hst.h"
 
-namespace 
-{
-  inline unsigned int ICACHE_RAM_ATTR readHardwareTime()
-  {
-    // Background, https://sub.nanona.fi/esp8266/timing-and-ticks.html
-    //
-    unsigned int ccount;
-    asm volatile ("rsr %0, ccount" : "=r"(ccount));
-    return ccount;
-  }
-
-} // end anonymous namespace
-
 namespace Time {
   ESP8266_HST::ESP8266_HST()
   {
@@ -24,15 +11,6 @@ namespace Time {
   DeviceTimeMS ESP8266_HST::msSinceDeviceStart()
   {
     return DeviceTimeMS(millis() - baseHardwareTimeMS );
-  }
-
-  constexpr unsigned int reduce=80;
-
-  DeviceTimeUS ICACHE_RAM_ATTR ESP8266_HST::usSinceDeviceStart()
-  {
-    const unsigned int ticksSinceBase = readHardwareTime() - baseHardwareTime; 
-    const unsigned int usSinceBase = ticksSinceBase / reduce;
-    return currentTime + usSinceBase;
   }
 
   TimeUS ESP8266_HST::execute()

--- a/firmware/time_esp8266hst.cpp
+++ b/firmware/time_esp8266hst.cpp
@@ -3,7 +3,7 @@
 
 namespace 
 {
-  inline unsigned int readHardwareTime()
+  inline unsigned int ICACHE_RAM_ATTR readHardwareTime()
   {
     // Background, https://sub.nanona.fi/esp8266/timing-and-ticks.html
     //
@@ -28,7 +28,7 @@ namespace Time {
 
   constexpr unsigned int reduce=80;
 
-  DeviceTimeUS ESP8266_HST::usSinceDeviceStart()
+  DeviceTimeUS ICACHE_RAM_ATTR ESP8266_HST::usSinceDeviceStart()
   {
     const unsigned int ticksSinceBase = readHardwareTime() - baseHardwareTime; 
     const unsigned int usSinceBase = ticksSinceBase / reduce;

--- a/firmware/util_ipinevents.h
+++ b/firmware/util_ipinevents.h
@@ -2,7 +2,7 @@
 #define __UTIL_IPINEVENTS_H__
 
 #include <array>
-#include "hardware_interface.h"   // For HW::PinState
+#include "hardware_types.h"       // For HW::PinState
 #include "time_types.h"           // For Time::DeviceTimeUS
 
 namespace Util {

--- a/firmware/util_ipinevents.h
+++ b/firmware/util_ipinevents.h
@@ -2,13 +2,13 @@
 #define __UTIL_IPINEVENTS_H__
 
 #include <array>
-#include "hardware_interface.h"   // For HWI::PinState
+#include "hardware_interface.h"   // For HW::PinState
 #include "time_types.h"           // For Time::DeviceTimeUS
 
 namespace Util {
 
 /// A single event for IPinEvents
-using IPinEvent = std::pair< HWI::PinState, Time::DeviceTimeUS >; 
+using IPinEvent = std::pair< HW::PinState, Time::DeviceTimeUS >; 
 
 ///
 /// @brief Record changes in an input, and the time the change occured

--- a/firmware/util_ipinevents.h
+++ b/firmware/util_ipinevents.h
@@ -60,7 +60,7 @@ class IPinEvents
 
   /// @brief Write an event to the pipe.  Set error flag on overflow
   /// 
-  void write( const IPinEvent& event ) noexcept {
+  OCTO_INTERRUPT_FUNC(void) write( const IPinEvent& event ) noexcept {
     // Find the next empty write slot
     const std::size_t nextWriteSlot = ( writeSlot + 1 ) % N;
 
@@ -118,8 +118,15 @@ class IPinEvents
   bool writeErrorFlag;
   // Set to true if we underflow on read
   bool readErrorFlag;
-  // The actual events.
-  std::array< IPinEvent, N > events;
+  //
+  // The actual events...
+  //  
+  // I'd prefer to use an std::array here, because it's 2020, but this code 
+  // will be used by the interrupt and I want to guarantee the compiler
+  // doesn't add a function for the [] operator (as unlikely as it seems)
+  //
+  //std::array< IPinEvent, N > events;
+  IPinEvent events[N];
 };
 
 ///

--- a/firmware/util_profile.cpp
+++ b/firmware/util_profile.cpp
@@ -19,7 +19,7 @@ void Profile::reset()
 
 void Profile::addSample( Time::TimeUS sample )
 {
-  while ( sample > maxTime ) {
+  while ( sample >= maxTime ) {
     compress();
   }
   size_t slot = sample.get() / currentScale;

--- a/firmware_sim/main.cpp
+++ b/firmware_sim/main.cpp
@@ -4,6 +4,7 @@
 #include <unistd.h>
 #include <time.h>
 #include <math.h>   // for adding variation to simulated temperature.
+#include <map>    
 
 #include "command_datasend.h"
 #include "command_motor.h"
@@ -169,6 +170,15 @@ class ISim: public I
 
     return 200 + count_amp;
   }
+
+  IEvent& GetInputEvents( Pin pin ) override
+  {
+    return pinToEventMap[ pin ];
+  }
+
+  private:
+
+  std::map< Pin, IEvent > pinToEventMap;
 };
 }; // end HW namespace
 

--- a/firmware_sim/main.cpp
+++ b/firmware_sim/main.cpp
@@ -140,24 +140,25 @@ class NetInterfaceSim: public NetInterface {
   NetConnectionSim defaultConnection;
 };
 
-class HWISim: public HWI
+namespace HW {
+class ISim: public I
 {
   public: 
 
   void PinMode( Pin pin, PinIOMode mode ) override
   {
-    std::cout << "PM (" << HWI::pinNames.at(pin) << ") = " << HWI::pinIOModeNames.at(mode) << "\n";
+    std::cout << "PM (" << HW::pinNames.at(pin) << ") = " << HW::pinIOModeNames.at(mode) << "\n";
   }
   void DigitalWrite( Pin pin, PinState state ) override
   {
-    const std::string name = HWI::pinNames.at(pin);
-    std::cout << "DW (" << HWI::pinNames.at(pin) 
-              << ") = " << HWI::pinStateNames.at( state ) 
+    const std::string name = HW::pinNames.at(pin);
+    std::cout << "DW (" << HW::pinNames.at(pin) 
+              << ") = " << HW::pinStateNames.at( state ) 
               << "\n";
   }
   PinState DigitalRead( Pin pin ) override
   {
-    return HWI::PinState::INPUT_LOW;
+    return HW::PinState::INPUT_LOW;
   }
   unsigned AnalogRead( Pin pin ) override
   {
@@ -169,6 +170,7 @@ class HWISim: public HWI
     return 200 + count_amp;
   }
 };
+}; // end HW namespace
 
 class DebugInterfaceSim: public DebugInterface
 {
@@ -193,7 +195,7 @@ Time::TimeUS loop() {
 void setup() {
   auto debug      = std::make_shared<DebugInterfaceSim>();
   auto wifi       = std::make_shared<NetInterfaceSim>( debug );
-  auto hardware   = std::make_shared<HWISim>();
+  auto hardware   = std::make_shared<HW::ISim>();
   auto hst        = std::make_shared<SimTimeHST>();
 
   scheduler = std::make_shared<Command::Scheduler>( 
@@ -203,20 +205,20 @@ void setup() {
   auto time       = std::make_shared<Time::Manager>( timeSim, hst );
   auto motorSimA  = std::make_shared<Command::Motor>( 
                           hardware, debug, wifi, 
-                          HWI::Pin::MOTOR0_PIN0, HWI::Pin::MOTOR0_PIN1 );
+                          HW::Pin::MOTOR0_PIN0, HW::Pin::MOTOR0_PIN1 );
   auto motorSimB  = std::make_shared<Command::Motor>( 
                           hardware, debug, wifi, 
-                          HWI::Pin::MOTOR1_PIN0, HWI::Pin::MOTOR1_PIN1 );
+                          HW::Pin::MOTOR1_PIN0, HW::Pin::MOTOR1_PIN1 );
   auto encoderASim = std::make_shared<Command::Encoder>(
                           hardware, debug, wifi, 
-                          HWI::Pin::ENCODER0_PIN0, HWI::Pin::ENCODER0_PIN1);
+                          HW::Pin::ENCODER0_PIN0, HW::Pin::ENCODER0_PIN1);
   auto encoderBSim = std::make_shared<Command::Encoder>(
                           hardware, debug, wifi, 
-                          HWI::Pin::ENCODER1_PIN0, HWI::Pin::ENCODER1_PIN1);
+                          HW::Pin::ENCODER1_PIN0, HW::Pin::ENCODER1_PIN1);
  
   auto sr04        = std::make_shared<Command::SR04> (
                           hardware, debug, wifi, hst,
-                          HWI::Pin::SR04_TRIG, HWI::Pin::SR04_ECHO );
+                          HW::Pin::SR04_TRIG, HW::Pin::SR04_ECHO );
 
   auto dataSend = std::make_shared<Command::DataSend>( 
                           debug, wifi, 

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -3,6 +3,7 @@ ENABLE_TESTING()
 SET(UNIT_TESTS test_check_for_commands test_device test_enums test_profile test_pipe test_ipinevents )
 
 add_library( firmware_test_lib STATIC ${FIRMWARE_SOURCES} )
+add_definitions( -DPC_BUILD )
 
 foreach( TEST ${UNIT_TESTS} )
 

--- a/unit_tests/test_device.cpp
+++ b/unit_tests/test_device.cpp
@@ -6,33 +6,33 @@
 /// @brief Every Pin in the Pins enum should have a debug name
 TEST( DEVICE, should_have_complete_pin_names )
 {
-  for( HWI::Pin pin = HWI::Pin::START_OF_PINS; 
-       pin < HWI::Pin::END_OF_PINS;
+  for( HW::Pin pin = HW::Pin::START_OF_PINS; 
+       pin < HW::Pin::END_OF_PINS;
        ++pin )
   {
-    ASSERT_NE(HWI::pinNames.find( pin ), HWI::pinNames.end() );
+    ASSERT_NE(HW::pinNames.find( pin ), HW::pinNames.end() );
   }
 }
 
 /// @brief Every Pin State the PinsState enum should have a debug name
 TEST( DEVICE, should_have_complete_pin_state_names )
 {
-  for( HWI::PinState pinState = HWI::PinState::START_OF_PIN_STATES; 
-       pinState < HWI::PinState::END_OF_PIN_STATES;
+  for( HW::PinState pinState = HW::PinState::START_OF_PIN_STATES; 
+       pinState < HW::PinState::END_OF_PIN_STATES;
        ++pinState )
   {
-    ASSERT_NE(HWI::pinStateNames.find( pinState ), HWI::pinStateNames.end() );
+    ASSERT_NE(HW::pinStateNames.find( pinState ), HW::pinStateNames.end() );
   }
 }
 
 /// @brief Every IO Mode should have a debug name
 TEST( DEVICE, should_have_complete_pin_io_modes )
 {
-  for( HWI::PinIOMode i= HWI::PinIOMode::START_OF_PIN_IO_MODES; 
-       i < HWI::PinIOMode::END_OF_IO_MODES;
+  for( HW::PinIOMode i= HW::PinIOMode::START_OF_PIN_IO_MODES; 
+       i < HW::PinIOMode::END_OF_IO_MODES;
        ++i )
   {
-    ASSERT_NE(HWI::pinIOModeNames.find( i ), HWI::pinIOModeNames.end() );
+    ASSERT_NE(HW::pinIOModeNames.find( i ), HW::pinIOModeNames.end() );
   }
 }
 

--- a/unit_tests/test_ipinevents.cpp
+++ b/unit_tests/test_ipinevents.cpp
@@ -199,7 +199,7 @@ TEST( pipe_should, merge_properly )
     events1.write( event );
   }
 
-  IPinEventMerger<IPinEvents<15>,IPinEvents<15>> merger( events0, events1 );
+  IPinEventMerger<IPinEvents<15>,IPinEvents<15>> merger( &events0, &events1 );
 
   std::vector< MergedEvent > mergedEvents;
   while( merger.hasEvents() ) {
@@ -237,7 +237,7 @@ TEST( pipe_should, merge_case_2 )
 
   IPinEvents<15> events1;
 
-  IPinEventMerger<IPinEvents<15>,IPinEvents<15>> merger( events0, events1 );
+  IPinEventMerger<IPinEvents<15>,IPinEvents<15>> merger( &events0, &events1 );
 
   std::vector< MergedEvent > mergedEvents;
   while( merger.hasEvents() ) {
@@ -275,7 +275,7 @@ TEST( pipe_should, merge_case_3 )
     events1.write( event );
   }
 
-  IPinEventMerger<IPinEvents<15>,IPinEvents<15>> merger( events0, events1 );
+  IPinEventMerger<IPinEvents<15>,IPinEvents<15>> merger( &events0, &events1 );
 
   std::vector< MergedEvent > mergedEvents;
   while( merger.hasEvents() ) {
@@ -319,7 +319,7 @@ TEST( pipe_should, debounce_properly )
   }
 
   // Create the filter
-  IPinDebouncer<IPinEvents<15>> debouncer( events, 20 );
+  IPinDebouncer<IPinEvents<15>> debouncer( &events, 20 );
 
   // Draw from the filter.
   std::vector< IPinEvent > deBouncedEvents;
@@ -387,11 +387,15 @@ TEST( pipe_should, computeGreyCodesProperly )
     events1.write( event );
   } 
 
-  GreyCodeTracker< IPinEvents<15>, IPinEvents<15> > tracker(
-      0,        // Start with grey code 0
-      events0,  // Events on pin 0
-      events1,  // Events on pin 1,
-      50 );     // 50us debounce window 
+  // Create debounces with a 50us debounce window
+  using DeBounce = Util::IPinDebouncer< IPinEvents<15> >;
+  DeBounce deBounce0( &events0, 50 );
+  DeBounce deBounce1( &events1, 50 );
+
+  GreyCodeTracker< DeBounce, DeBounce > tracker(
+      0,              // Start with grey code 0
+      &deBounce0,     // Debounced Events on pin 0
+      &deBounce1);    // Debounced Events on pin 1,
 
   std::vector<GreyCodeTime> result;
 

--- a/unit_tests/test_ipinevents.cpp
+++ b/unit_tests/test_ipinevents.cpp
@@ -16,9 +16,9 @@ TEST( pipe_should, add_and_remove_events )
   IPinEvents<16> events;
 
   const std::vector<IPinEvent> golden = {
-    { HWI::PinState::INPUT_HIGH, Time::DeviceTimeUS{1} },
-    { HWI::PinState::INPUT_LOW,  Time::DeviceTimeUS{2} },
-    { HWI::PinState::INPUT_HIGH, Time::DeviceTimeUS{3} }
+    { HW::PinState::INPUT_HIGH, Time::DeviceTimeUS{1} },
+    { HW::PinState::INPUT_LOW,  Time::DeviceTimeUS{2} },
+    { HW::PinState::INPUT_HIGH, Time::DeviceTimeUS{3} }
   };
 
   // 100 loops should be a good stress test
@@ -59,9 +59,9 @@ TEST( pipe_should, write_to_full )
   // Full is one less than the max (3) under the current implementation
   //
   const std::vector<IPinEvent> golden = {
-    { HWI::PinState::INPUT_HIGH, Time::DeviceTimeUS{1} },
-    { HWI::PinState::INPUT_LOW,  Time::DeviceTimeUS{2} },
-    { HWI::PinState::INPUT_HIGH, Time::DeviceTimeUS{3} }
+    { HW::PinState::INPUT_HIGH, Time::DeviceTimeUS{1} },
+    { HW::PinState::INPUT_LOW,  Time::DeviceTimeUS{2} },
+    { HW::PinState::INPUT_HIGH, Time::DeviceTimeUS{3} }
   };
 
   // 100 = stress test
@@ -98,10 +98,10 @@ TEST( pipe_should, error_on_write_fail )
   
   // Size 4 pipe can only hold 3 events, so feed it four events
   const std::vector<IPinEvent> golden = {
-    { HWI::PinState::INPUT_HIGH, Time::DeviceTimeUS{1} },
-    { HWI::PinState::INPUT_HIGH, Time::DeviceTimeUS{2} },
-    { HWI::PinState::INPUT_LOW,  Time::DeviceTimeUS{3} },
-    { HWI::PinState::INPUT_LOW,  Time::DeviceTimeUS{4} }
+    { HW::PinState::INPUT_HIGH, Time::DeviceTimeUS{1} },
+    { HW::PinState::INPUT_HIGH, Time::DeviceTimeUS{2} },
+    { HW::PinState::INPUT_LOW,  Time::DeviceTimeUS{3} },
+    { HW::PinState::INPUT_LOW,  Time::DeviceTimeUS{4} }
   };
   for ( const auto& event : golden ) {
     events.write( event );
@@ -126,7 +126,7 @@ TEST( pipe_should, error_on_write_fail )
 TEST( pipe_should, error_on_read_fail )
 {
   IPinEvent event = 
-    { HWI::PinState::INPUT_LOW,  Time::DeviceTimeUS{1} };
+    { HW::PinState::INPUT_LOW,  Time::DeviceTimeUS{1} };
 
   // Go through some test permutations...
   //

--- a/unit_tests/test_mock_event.h
+++ b/unit_tests/test_mock_event.h
@@ -15,16 +15,16 @@
 ///
 /// Examples:
 ///
-/// Event   : HWEvent( HWI::Pin::DIR,   HWI::PinState::Dir_FIRWARD )
+/// Event   : HWEvent( HW::Pin::DIR,   HW::PinState::Dir_FIRWARD )
 /// Meaning : The stepper motor direction pin is set to "go forward"
 /// 
-/// Event   : HWEvent( HWI::Pin::DIR,   HWI::PinIOMode::M_OUTPUT )
+/// Event   : HWEvent( HW::Pin::DIR,   HW::PinIOMode::M_OUTPUT )
 /// Meaning : The stepper motor direction GPIO is set to output mode
 /// 
-/// Event   : HWEvent( HWI::Pin::HOME,  HWI::PinIOMode::M_INPUT )
+/// Event   : HWEvent( HW::Pin::HOME,  HW::PinIOMode::M_INPUT )
 /// Meaning : The stepper motor home GPIO is set to input mode
 /// 
-/// Event   : HWEvent( HWI::Pin::HOME,  HWI::PinState::HOME_ACTIVE )
+/// Event   : HWEvent( HW::Pin::HOME,  HW::PinState::HOME_ACTIVE )
 /// Meaning : The home pin's input is now active (i.e., the focuser
 ///           is in the home position & the home switch was activated).
 ///
@@ -43,7 +43,7 @@ class HWEvent
   /// @param[in]  The pin that the read or write takes place on
   /// @param[in]  The new pin state.
   /// 
-  HWEvent( HWI::Pin pinRHS, HWI::PinState stateRHS ) :
+  HWEvent( HW::Pin pinRHS, HW::PinState stateRHS ) :
     pin{ pinRHS },
     type{ Type::DIGITAL_IO },
     state{ stateRHS }
@@ -56,7 +56,7 @@ class HWEvent
   /// @param[in]  The pin that we're setting the GPIO mode on
   /// @param[in]  The new mode (i.e.,  output or input )
   /// 
-  HWEvent( HWI::Pin pinRHS, HWI::PinIOMode modeRHS) :
+  HWEvent( HW::Pin pinRHS, HW::PinIOMode modeRHS) :
     pin{ pinRHS },
     type{ Type::PIN_MODE },
     mode{ modeRHS }
@@ -81,21 +81,21 @@ class HWEvent
   bool isMode() const { return type == Type::PIN_MODE ; }
 
   /// @brief Get the new state for an IO read or write event
-  HWI::PinState getIO() const
+  HW::PinState getIO() const
   {
     assert( isIO() );
     return state;
   }
 
   /// @brief Get the new mode for a set GPIO mode event.
-  HWI::PinIOMode getMode() const
+  HW::PinIOMode getMode() const
   {
     assert( isMode() );
     return mode;
   }
  
   /// @brief Get the pin
-  HWI::Pin getPin() const { return pin; }
+  HW::Pin getPin() const { return pin; }
 
   private:
 
@@ -105,12 +105,12 @@ class HWEvent
     PIN_MODE,     // An event where the GPIO is set to Input or Output
   };
 
-  HWI::Pin pin;
+  HW::Pin pin;
   Type type;
 
   union {
-    HWI::PinState state;
-    HWI::PinIOMode mode;
+    HW::PinState state;
+    HW::PinIOMode mode;
   };
 };
 
@@ -126,14 +126,14 @@ inline std::ostream& operator<<(
   std::ostream& stream, 
   const HWEvent& event) 
 {
-  stream << "{ PIN: " << HWI::pinNames.at( event.getPin() );
+  stream << "{ PIN: " << HW::pinNames.at( event.getPin() );
   if ( event.isIO() )
   {
-    stream << " IO:    " << HWI::pinStateNames.at(event.getIO() ); 
+    stream << " IO:    " << HW::pinStateNames.at(event.getIO() ); 
   }
   else
   {
-    stream << " MODE:  " << HWI::pinIOModeNames.at(event.getMode() ); 
+    stream << " MODE:  " << HW::pinIOModeNames.at(event.getMode() ); 
   }
   stream << " }";
   return stream;

--- a/unit_tests/test_mock_hardware.h
+++ b/unit_tests/test_mock_hardware.h
@@ -11,7 +11,7 @@
 ///
 /// @brief Testing Mock for hardware events
 /// 
-/// HWMockTimed implements a mock Hardware Interface (HWI) that's used in
+/// MockTimed implements a mock Hardware Interface (HWI) that's used in
 /// unit testing.  The class implements testing mocks for the interfaces
 /// required by the HWI class.  In addition to that, the class does the
 /// following:
@@ -28,7 +28,8 @@
 ///     events and the time those events occur at.  i.e.,  the caller can
 ///     see "at time 20ms the HOME input will change state to active"
 /// 
-class HWMockTimed: public HWI
+namespace HW {
+class MockTimed: public I
 {
   public:
 
@@ -38,7 +39,7 @@ class HWMockTimed: public HWI
   ///   input events and they time they take place at.  See 
   ///   HWTimedEvents for examples. 
   ///
-  HWMockTimed( const HWTimedEvents& hwIn ) : 
+  MockTimed( const HWTimedEvents& hwIn ) : 
       time{ 0 }, 
       inEvents{ hwIn },
       nextInputEvent{inEvents.begin()}
@@ -49,10 +50,10 @@ class HWMockTimed: public HWI
   }
 
   // delete unused operators for safety
-  HWMockTimed() = delete;
-  HWMockTimed( const HWMockTimed& ) = delete;
-  HWMockTimed& operator=( const HWMockTimed& ) = delete;
-  virtual ~HWMockTimed() {}
+  MockTimed() = delete;
+  MockTimed( const MockTimed& ) = delete;
+  MockTimed& operator=( const MockTimed& ) = delete;
+  virtual ~MockTimed() {}
 
   ///
   /// @brief Mock DigitalWrite hardware interface
@@ -91,17 +92,17 @@ class HWMockTimed: public HWI
   ///
   /// @code
   ///   HWTimedEvents hwInput= {
-  ///     { 0,   { HWI::Pin::HOME,        HWI::PinState::HOME_INACTIVE} },
-  ///     { 10,  { HWI::Pin::HOME,        HWI::PinState::HOME_INACTIVE} },
+  ///     { 0,   { HW::Pin::HOME,        HW::PinState::HOME_INACTIVE} },
+  ///     { 10,  { HW::Pin::HOME,        HW::PinState::HOME_INACTIVE} },
   ///   };
   /// 
-  ///   HWMockTimed hw( hwInput ) : 
+  ///   MockTimed hw( hwInput ) : 
   /// 
-  ///   hw.DigitalRead( HWI::Pin::HOME )  // Will return HOME_INACTIVE
+  ///   hw.DigitalRead( HW::Pin::HOME )  // Will return HOME_INACTIVE
   ///   hw.advanceTime( 5 )               // Time = 5
-  ///   hw.DigitalRead( HWI::Pin::HOME )  // Will still return HOME_INACTIVE
+  ///   hw.DigitalRead( HW::Pin::HOME )  // Will still return HOME_INACTIVE
   ///   hw.advanceTime( 5 )               // Time = 10
-  ///   hw.DigitalRead( HWI::Pin::HOME )  // Will now return HOME_ACTIVE
+  ///   hw.DigitalRead( HW::Pin::HOME )  // Will now return HOME_ACTIVE
   /// @endcode
   ///
   PinState DigitalRead( Pin pin ) override
@@ -144,23 +145,23 @@ class HWMockTimed: public HWI
   ///
   /// @code
   ///   HWTimedEvents hwInput;  // No input
-  ///   HWMockTimed hw( hwInput ) : 
+  ///   MockTimed hw( hwInput ) : 
   ///   // Set Stepper Pin to Output
-  ///   hw.PinMode( HWI::Pin::STEP,   HWI::PinIOMode::M_OUTPUT );
-  ///   hw.PinMode( HWI::Pin::STEP,   HWI::PinState::STEP_INACTIVE);
+  ///   hw.PinMode( HW::Pin::STEP,   HW::PinIOMode::M_OUTPUT );
+  ///   hw.PinMode( HW::Pin::STEP,   HW::PinState::STEP_INACTIVE);
   ///
   ///   // Do a step
   ///   hw.advanceTime( 10 )
-  ///   hw.PinMode( HWI::Pin::STEP,   HWI::PinState::STEP_ACTIVE);
+  ///   hw.PinMode( HW::Pin::STEP,   HW::PinState::STEP_ACTIVE);
   ///   hw.advanceTime( 1 )
-  ///   hw.PinMode( HWI::Pin::STEP,   HWI::PinState::STEP_INACTIVE);
+  ///   hw.PinMode( HW::Pin::STEP,   HW::PinState::STEP_INACTIVE);
   /// 
   ///   // Golden Results
   ///   HWTimedEvents goldenHW = {
-  ///     { 0,  {HWI::Pin::Step,   HWI::PinIOMode::M_OUTPUT      } },
-  ///     { 0,  {HWI::Pin::Step,   HWI::PinState::STEP_INACTIVE  } },
-  ///     { 10, {HWI::Pin::Step,   HWI::PinState::STEP_ACTIVE } },
-  ///     { 11, {HWI::Pin::Step,   HWI::PinState::STEP_ACTIVE } }
+  ///     { 0,  {HW::Pin::Step,   HW::PinIOMode::M_OUTPUT      } },
+  ///     { 0,  {HW::Pin::Step,   HW::PinState::STEP_INACTIVE  } },
+  ///     { 10, {HW::Pin::Step,   HW::PinState::STEP_ACTIVE } },
+  ///     { 11, {HW::Pin::Step,   HW::PinState::STEP_ACTIVE } }
   ///   }
   ///   // Compare
   ///   ASSERT_EQ( goldenHw, hw.getOutEvents()); 
@@ -183,6 +184,7 @@ class HWMockTimed: public HWI
   /// @brief  The current state of each input pin.
   std::unordered_map<Pin,PinState,EnumHash> inputStates;
 };
+}; // End HW namespace
 
 #endif
 

--- a/unit_tests/test_mock_net.h
+++ b/unit_tests/test_mock_net.h
@@ -106,7 +106,7 @@ class NetMockSimpleTimed: public NetInterface
   }
 
   // delete unused operators for safety
-  NetMockSimpleTimed( const HWMockTimed& ) = delete;
+  NetMockSimpleTimed( const HW::MockTimed& ) = delete;
   NetMockSimpleTimed& operator=( const NetMockSimpleTimed& ) = delete;
 
 


### PR DESCRIPTION
- Create tested utilities for recording and reasoning about events without allocated memory during robot operation, which is dangerous in a micro-controller environment.
- Expose an event driven interface in the hardware abstraction
- Use the new interfaces in the encoder command.

TODO - populate the events using actual hardware interupts.  Right now it's still polling under the hood.
