### PR TITLE
Tune range finder LEDs

### DIFF
--- a/firmware/command_datasend.cpp
+++ b/firmware/command_datasend.cpp
@@ -16,9 +16,7 @@ DataSend::DataSend(
   encoderL{ encoderLArg },
   encoderR{ encoderRArg },
   rangeFinder{ rangeFinderArg },
-  hwi{ hwiArg},
-  isOutputting{ false },
-  timesCalled{ 0 }
+  hwi{ hwiArg}
 {
 }
 
@@ -63,17 +61,24 @@ void DataSend::updateLEDs()
   //
   // 1. Use the Sonar Range finder current distance for the center color
   // 
-  int range = rangeFinder->getLastSensorReading();
-  if ( range < 0 ) {
+  const int range = rangeFinder->getLastSensorReading();
+  if ( range >= 0 ) { 
+    lastValidSensorReading = range;
+  }
+  if ( lastValidSensorReading < 0 ) {
     center[ R ] = 0;
     center[ G ] = 255;
     center[ B ] = 0;
   }
   else {
-    // max 140cm, or 1400mm
-    range = std::min( range, 1400 );
-    // Blue is cold ( like the hotter / colder game ).  Set to full at max
-    center[ B ] = 255 * range / 1400;
+    // Display a color from red to blue, depending on how close the wall
+    // is.  Red = closer (hotter), blue = further (colder).  For the purpose
+    // of the display, go full blue at 500mm, or 50cm.
+    constexpr int maxRangeForDisplayPurposes = 500;
+    const int drange = std::min( lastValidSensorReading , maxRangeForDisplayPurposes );
+    // Full Blue:  drange = maxRangeForDisplayPurposes 
+    // Full Red:   drange = 0
+    center[ B ] = 255 * drange / maxRangeForDisplayPurposes;
     center[ R ] = 255 - center[B];
     center[ G ] = 0;
   }

--- a/firmware/command_datasend.h
+++ b/firmware/command_datasend.h
@@ -72,9 +72,11 @@ class DataSend: public Base {
   // @brief Interface to hardware, for setting LEDs.
   std::shared_ptr<HW::I>  hwi;
   // @brief Are we currently outputting data
-  bool isOutputting;
+  bool isOutputting = false;
   // @brief How many times have we been called?
-  unsigned int timesCalled;
+  unsigned int timesCalled  = 0;
+  // @brief Last valid sensor reading - for LED display only.  Default = invalid
+  int lastValidSensorReading = -1;
 };
 
 }; // end Command namespace.


### PR DESCRIPTION
- Ignore invalid sensor requests.  The green flashes are visually distracting
- Move the "far" from 140cm to 50cm.
- Remove magic number.