### PR TITLE
Separate out odometry

### DIFF
--- a/example code/positiontutorial/src/main/java/frc/robot/RobotContainer.java
+++ b/example code/positiontutorial/src/main/java/frc/robot/RobotContainer.java
@@ -10,6 +10,7 @@ package frc.robot;
 import frc.robot.commands.AutonomousCommand;
 import frc.robot.commands.TeleopCommand;
 import frc.robot.subsystems.OctoDriveSubsystem;
+import frc.robot.subsystems.Odometry;
 import edu.wpi.first.wpilibj2.command.Command;
 
 /**
@@ -23,9 +24,7 @@ public class RobotContainer {
   
   private final OctoDriveSubsystem m_octoDriveSubsystem = new OctoDriveSubsystem();
   private final TeleopCommand m_teleopCommand = new TeleopCommand(m_octoDriveSubsystem);
-  private final AutonomousCommand m_autonomousCommand = new AutonomousCommand(m_octoDriveSubsystem);
-
-
+  private final AutonomousCommand m_autonomousCommand = new AutonomousCommand(m_octoDriveSubsystem, new Odometry( m_octoDriveSubsystem ));
 
   /**
    * The container for the robot.  Contains subsystems, IO devices, and commands.

--- a/example code/positiontutorial/src/main/java/frc/robot/commands/AutonomousCommand.java
+++ b/example code/positiontutorial/src/main/java/frc/robot/commands/AutonomousCommand.java
@@ -10,6 +10,7 @@ package frc.robot.commands;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.robot.subsystems.OctoDriveSubsystem;
+import frc.robot.subsystems.Odometry;
 import frc.robot.commands.MoveToCommand;
 import frc.robot.commands.TurnCommand;
 import edu.wpi.first.wpilibj.geometry.*;
@@ -28,24 +29,24 @@ public class AutonomousCommand extends CommandBase {
      * Autonomous mode constructor.  Sets the sequence of commands we want the robot to follow.
      * @param drive This is the Robot's drive.  Used to get odometry and set motor speeds.
      */
-    public AutonomousCommand(OctoDriveSubsystem drive ) {
+    public AutonomousCommand(OctoDriveSubsystem drive, Odometry odometry ) {
         // A sequence of commands to move the robot autonomously in a triangle.
         // The robot returns to its start position
         commandList = new SequentialCommandGroup(
             // Move to coordinate <1.0,0> (meters).  The robot starts at <0,0>, facing
             // the X axis, so this is essentially a move forward
-            new MoveToCommand( drive, new Translation2d( 1.0, 0.0 ) ),
+            new MoveToCommand( drive, odometry, new Translation2d( 1.0, 0.0 ) ),
             // Sharp Left turn to get us close to 90 degrees
-            new TurnCommand   ( drive, new Rotation2d(Math.toRadians(75.0)) ),
+            new TurnCommand  ( drive, odometry, new Rotation2d(Math.toRadians(75.0)) ),
             // The robot should now be at <1.0,0>, facing close to 90 degrees.  Going
             // forward now will move the robot along the Y axis.   
             // A "Move To" <1.0,0.50> command should move the robot forward about 50cm 
-            new MoveToCommand( drive, new Translation2d( 1.0, 0.5 )),  
+            new MoveToCommand( drive, odometry, new Translation2d( 1.0, 0.5 )),  
             // Another sharp turn.  This will turn the robot back toward where it started
             // (just over 180 degrees)          
-            new TurnCommand   ( drive, new Rotation2d(Math.toRadians( 190 )) ),      
+            new TurnCommand  ( drive, odometry, new Rotation2d(Math.toRadians( 190 )) ),      
             // Move back to the start.    
-            new MoveToCommand( drive, new Translation2d(0.0, 0.0 ))  
+            new MoveToCommand( drive, odometry, new Translation2d(0.0, 0.0 ))  
         );
     }
 

--- a/example code/positiontutorial/src/main/java/frc/robot/commands/MoveToCommand.java
+++ b/example code/positiontutorial/src/main/java/frc/robot/commands/MoveToCommand.java
@@ -3,6 +3,7 @@ package frc.robot.commands;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import edu.wpi.first.wpilibj.geometry.*;
 import frc.robot.subsystems.OctoDriveSubsystem;
+import frc.robot.subsystems.Odometry;
 
 /**
  * Command that moves the rebot to a desired location in 2D space
@@ -10,8 +11,11 @@ import frc.robot.subsystems.OctoDriveSubsystem;
 public class MoveToCommand extends CommandBase {
     @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
     
-    // The drive we use to get odometry from and set motor speeds
+    // The drive we use to set motor speeds
     private OctoDriveSubsystem drive;
+
+    // The source of our odometry (robot position & orientation)
+    private Odometry odometry;
 
     // The location in 2D space we're trying to get to.
     private Translation2d desiredTranslation;
@@ -30,8 +34,9 @@ public class MoveToCommand extends CommandBase {
      * but it may do so in a large, sweeping arch.
      * 
      */
-    public MoveToCommand(OctoDriveSubsystem driveArg, Translation2d targetArg ) {
+    public MoveToCommand(OctoDriveSubsystem driveArg, Odometry odometryArg, Translation2d targetArg ) {
         drive = driveArg;
+        odometry = odometryArg;
         desiredTranslation = targetArg;
     }
 
@@ -63,7 +68,7 @@ public class MoveToCommand extends CommandBase {
         //
         // dTarget == how do we change our current position to get to the target
         //
-        final Pose2d position = drive.getPoseMeters();
+        final Pose2d position = odometry.getPoseMeters();
         final Translation2d currentTranslation = position.getTranslation();
         final Translation2d deltaTarget = desiredTranslation.minus( currentTranslation );
         final double distanceLeft = deltaTarget.getNorm();       

--- a/example code/positiontutorial/src/main/java/frc/robot/commands/TurnCommand.java
+++ b/example code/positiontutorial/src/main/java/frc/robot/commands/TurnCommand.java
@@ -2,6 +2,7 @@ package frc.robot.commands;
 
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.subsystems.OctoDriveSubsystem;
+import frc.robot.subsystems.Odometry;
 import edu.wpi.first.wpilibj.geometry.*;
 
 /**
@@ -10,20 +11,25 @@ import edu.wpi.first.wpilibj.geometry.*;
 public class TurnCommand extends CommandBase {
     @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
     
-    // The drive.  Used to set motor power & get odometry
+    // The drive.  Used to set motor power
     private OctoDriveSubsystem drive;
+    // The odometry tracker.  Used to get position & orientation
+    private Odometry odometry;
     // The desired rotation - what we're trying to achieve
     private Rotation2d desiredRotation;
     // Set to true when we're close to the desired rotation
     private boolean isFinishedFlag = false;
 
+
     /**
      * Command to turn toward a desired rotation
-     * @param driveArg              The drive.  USed to set motor power & get odemetry
+     * @param driveArg              The drive.  Used to set motor power
+     * @param odometryArg           Odometry tracker.  Used to figure out where we are
      * @param desiredRotationArg    The desired rotation
      */
-    public TurnCommand( OctoDriveSubsystem driveArg, Rotation2d desiredRotationArg) {
+    public TurnCommand( OctoDriveSubsystem driveArg, Odometry odometryArg, Rotation2d desiredRotationArg) {
         drive = driveArg;
+        odometry = odometryArg;
         desiredRotation = desiredRotationArg;
     }
 
@@ -50,7 +56,7 @@ public class TurnCommand extends CommandBase {
         //
         // 1. Compute the change we need to make to get to the desired heading (correctionRotation)
         //
-        final Rotation2d currentRotation = drive.getPoseMeters().getRotation();
+        final Rotation2d currentRotation = odometry.getPoseMeters().getRotation();
         final Rotation2d correctionRotation = desiredRotation.minus( currentRotation );
 
         //

--- a/example code/positiontutorial/src/main/java/frc/robot/lib/EncoderPair.java
+++ b/example code/positiontutorial/src/main/java/frc/robot/lib/EncoderPair.java
@@ -1,0 +1,56 @@
+ 
+ package frc.robot.lib;
+ 
+ /**
+  * Captures the concept of a left & right encoder pair
+  */
+public class EncoderPair {
+    public EncoderPair( double leftArg, double rightArg )
+    {
+      left = leftArg;
+      right = rightArg;
+    }
+
+    /**
+     * Subtracts the other from the current encoder and returns the result
+     * 
+     * @param other  What we want to subtract.  Result is this - other.
+     * @return       The difference betwene the current encoder and other.
+     */
+    public EncoderPair minus( EncoderPair other ) {
+      return new EncoderPair( left - other.left, right - other.right );
+    }
+
+    /*
+     * Returns the "magnitude" of the current encoder pair.  Can be used as a metric
+     * for figuring out how far a pair of wheels moved.
+     * 
+     * @return  The sum of the magnitude of the left & right encoder distance.
+     */
+    public double getMag() {
+      return Math.abs( left ) + Math.abs( right );
+    }
+
+    /**
+     * Convert the encoder state to a string.  Useful for debugging.
+     * 
+     * @return  A human readable string representing the encoder's state
+     */
+    public String toString()
+    {
+      return "EncoderP{ " + left + " , " + right + " }";
+    }
+
+    public double getLeft() 
+    {
+        return left;
+    }
+
+    public double getRight()
+    {
+        return right;
+    }
+
+    private double left;
+    private double right;
+  };

--- a/example code/positiontutorial/src/main/java/frc/robot/lib/EncoderPair.java
+++ b/example code/positiontutorial/src/main/java/frc/robot/lib/EncoderPair.java
@@ -5,52 +5,52 @@
   * Captures the concept of a left & right encoder pair
   */
 public class EncoderPair {
-    public EncoderPair( double leftArg, double rightArg )
-    {
-      left = leftArg;
-      right = rightArg;
-    }
+  public EncoderPair( double leftArg, double rightArg )
+  {
+    left = leftArg;
+    right = rightArg;
+  }
 
-    /**
-     * Subtracts the other from the current encoder and returns the result
-     * 
-     * @param other  What we want to subtract.  Result is this - other.
-     * @return       The difference betwene the current encoder and other.
-     */
-    public EncoderPair minus( EncoderPair other ) {
-      return new EncoderPair( left - other.left, right - other.right );
-    }
+  /**
+    * Subtracts the other from the current encoder and returns the result
+    * 
+    * @param other  What we want to subtract.  Result is this - other.
+    * @return       The difference betwene the current encoder and other.
+    */
+  public EncoderPair minus( EncoderPair other ) {
+    return new EncoderPair( left - other.left, right - other.right );
+  }
 
-    /*
-     * Returns the "magnitude" of the current encoder pair.  Can be used as a metric
-     * for figuring out how far a pair of wheels moved.
-     * 
-     * @return  The sum of the magnitude of the left & right encoder distance.
-     */
-    public double getMag() {
-      return Math.abs( left ) + Math.abs( right );
-    }
+  /**
+    * Returns the "magnitude" of the current encoder pair.  Can be used as a metric
+    * for figuring out how far a pair of wheels moved.
+    * 
+    * @return  The sum of the magnitude of the left & right encoder distance.
+    */
+  public double getMag() {
+    return Math.abs( left ) + Math.abs( right );
+  }
 
-    /**
-     * Convert the encoder state to a string.  Useful for debugging.
-     * 
-     * @return  A human readable string representing the encoder's state
-     */
-    public String toString()
-    {
-      return "EncoderP{ " + left + " , " + right + " }";
-    }
+  /**
+    * Convert the encoder state to a string.  Useful for debugging.
+    * 
+    * @return  A human readable string representing the encoder's state
+    */
+  public String toString()
+  {
+    return "EncoderP{ " + left + " , " + right + " }";
+  }
 
-    public double getLeft() 
-    {
-        return left;
-    }
+  public double getLeft() 
+  {
+    return left;
+  }
 
-    public double getRight()
-    {
-        return right;
-    }
+  public double getRight()
+  {
+    return right;
+  }
 
-    private double left;
-    private double right;
-  };
+  private double left;
+  private double right;
+};

--- a/example code/positiontutorial/src/main/java/frc/robot/lib/EncoderPairChange.java
+++ b/example code/positiontutorial/src/main/java/frc/robot/lib/EncoderPairChange.java
@@ -1,0 +1,34 @@
+package frc.robot.lib;
+ 
+ /**
+  * Used to compute the difference between the Drive Train's current & last encoder state
+  */
+public class EncoderPairChange {
+    private EncoderPairSource source;
+    private EncoderPair lastPos;
+
+    public EncoderPairChange( EncoderPairSource sourceArg )
+    {
+        source = sourceArg;
+        lastPos = source.getEncoderPos();
+    }
+
+    public EncoderPair getChange()
+    {
+        EncoderPair currentPos = source.getEncoderPos();
+        EncoderPair diff = currentPos.minus( lastPos );
+        lastPos = currentPos;
+        if ( diff.getMag() > 10.0 ) {
+            //
+            // Hack alert.  The trainer robot doesn't have the true encoder state
+            // at start up because the state is sent over the network, and the update
+            // might be delayed.  We're quietly consuming large changes here and
+            // pretending they never happened as a workaround.
+            //
+            // The fix is to tighten up the robot start-up semantics.
+            //
+            diff = new EncoderPair( 0.0, 0.0 );
+        } 
+        return diff;
+    }
+}

--- a/example code/positiontutorial/src/main/java/frc/robot/lib/EncoderPairSource.java
+++ b/example code/positiontutorial/src/main/java/frc/robot/lib/EncoderPairSource.java
@@ -1,0 +1,5 @@
+package frc.robot.lib;
+
+public interface EncoderPairSource {
+    public EncoderPair getEncoderPos();
+}

--- a/example code/positiontutorial/src/main/java/frc/robot/subsystems/OctoDriveSubsystem.java
+++ b/example code/positiontutorial/src/main/java/frc/robot/subsystems/OctoDriveSubsystem.java
@@ -11,35 +11,12 @@ import edu.wpi.first.wpilibj.drive.DifferentialDrive;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.lib.OctoEncoder;
 import frc.robot.lib.OctoSpeedController;
+import frc.robot.lib.EncoderPair;
 import edu.wpi.first.wpilibj.geometry.*;
 
 public class OctoDriveSubsystem extends SubsystemBase {
 
-  /**
-   * Captures the concept of a left & right encoder pair
-   */
-  class EncoderPair {
-    EncoderPair( double leftArg, double rightArg )
-    {
-      left = leftArg;
-      right = rightArg;
-    }
-    EncoderPair sub( EncoderPair rhs ) {
-      return new EncoderPair( left - rhs.left, right - rhs.right );
-    }
-
-    double mag() {
-      return Math.sqrt( left*left + right*right );
-    }
-
-    public String toString()
-    {
-      return "EncoderP{ " + left + " , " + right + " }";
-    }
-
-    public double left;
-    public double right;
-  };
+ 
 
   private double rightPower;
   private double leftPower;
@@ -159,7 +136,7 @@ public class OctoDriveSubsystem extends SubsystemBase {
     if ( lastEncoderPos == null ) {
       lastEncoderPos = currentEncoderPos;
     }
-    EncoderPair result = currentEncoderPos.sub( lastEncoderPos );
+    EncoderPair result = currentEncoderPos.minus( lastEncoderPos );
     lastEncoderPos = currentEncoderPos;
     return result;
   }
@@ -178,15 +155,15 @@ public class OctoDriveSubsystem extends SubsystemBase {
     // deltas that are ridiculously large.  TODO: should probably lock 
     // this down better.
     //
-    if ( d.mag() > 10.0 ) { return; }
-    if ( d.mag() < .01 ) { return; }
+    if ( d.getMag() > 10.0 ) { return; }
+    if ( d.getMag() < .01 ) { return; }
 
     // See https://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-186-mobile-autonomous-systems-laboratory-january-iap-2005/study-materials/odomtutorial.pdf
     // for details about the math.
 
     final double dBaseline = 17.0;   // Measured + experimental
-    final double phi = (d.right - d.left ) / dBaseline;
-    final double dCenter = ( d.left + d.right ) / 2.0;
+    final double phi = (d.getRight() - d.getLeft() ) / dBaseline;
+    final double dCenter = ( d.getLeft() + d.getRight() ) / 2.0;
 
     final Rotation2d deltaRotation = new Rotation2d( phi );
     final Translation2d deltaTranslation = new Translation2d( dCenter, 0.0 ).rotateBy( rotation );
@@ -202,5 +179,4 @@ public class OctoDriveSubsystem extends SubsystemBase {
       new Translation2d( translation.getX() / 100.0, translation.getY() / 100.0 ),
       new Rotation2d( rotation.getRadians() ) );
   }
-
 }

--- a/example code/positiontutorial/src/main/java/frc/robot/subsystems/OctoDriveSubsystem.java
+++ b/example code/positiontutorial/src/main/java/frc/robot/subsystems/OctoDriveSubsystem.java
@@ -29,10 +29,7 @@ public class OctoDriveSubsystem extends SubsystemBase implements EncoderPairSour
 
   private DifferentialDrive drive;
 
-  private Translation2d translation = new Translation2d();
-  private Rotation2d rotation = new Rotation2d();
 
-  EncoderPairChange encoderChangeTracker;
 
   /*
   OctoDriveSubsystem controls the movement of the wheels, it uses a WPIlib DifferentialDrive object. 
@@ -52,9 +49,6 @@ public class OctoDriveSubsystem extends SubsystemBase implements EncoderPairSour
 
     leftEncoder.reset();
     rightEncoder.reset();    
-
-    // Declare a class to track changes in the encoder, using this class as its data source
-    encoderChangeTracker = new EncoderPairChange( this );
   }
 
   /*
@@ -66,8 +60,6 @@ public class OctoDriveSubsystem extends SubsystemBase implements EncoderPairSour
   public void periodic() {
     rightEncoder.periodic();
     leftEncoder.periodic();
-    doOdometryUpdate();
-  
     drive.tankDrive(leftPower, rightPower);
   }
 
@@ -127,34 +119,4 @@ public class OctoDriveSubsystem extends SubsystemBase implements EncoderPairSour
     return new EncoderPair( left, right );
   }
 
-  /**
-   * Use left and right encoder data to estimate the robot's odometry
-   */
-  public void doOdometryUpdate(){
-
-    final EncoderPair d = encoderChangeTracker.getChange();
-
-    if ( d.getMag() < .01 ) { return; }
-
-    // See https://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-186-mobile-autonomous-systems-laboratory-january-iap-2005/study-materials/odomtutorial.pdf
-    // for details about the math.
-
-    final double dBaseline = 17.0;   // Measured + experimental
-    final double phi = (d.getRight() - d.getLeft() ) / dBaseline;
-    final double dCenter = ( d.getLeft() + d.getRight() ) / 2.0;
-
-    final Rotation2d deltaRotation = new Rotation2d( phi );
-    final Translation2d deltaTranslation = new Translation2d( dCenter, 0.0 ).rotateBy( rotation );
-    translation = translation.plus( deltaTranslation );
-    rotation = rotation.plus( deltaRotation );
-
-    return;
-  }
-
-  public Pose2d getPoseMeters() {
-    // "Clone" so we don't leak a reference to our internal data
-    return new Pose2d( 
-      new Translation2d( translation.getX() / 100.0, translation.getY() / 100.0 ),
-      new Rotation2d( rotation.getRadians() ) );
-  }
 }

--- a/example code/positiontutorial/src/main/java/frc/robot/subsystems/Odometry.java
+++ b/example code/positiontutorial/src/main/java/frc/robot/subsystems/Odometry.java
@@ -1,0 +1,53 @@
+package frc.robot.subsystems;
+
+import edu.wpi.first.wpilibj.geometry.*;
+import frc.robot.lib.EncoderPair;
+import frc.robot.lib.EncoderPairSource;
+import frc.robot.lib.EncoderPairChange;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+
+public class Odometry extends SubsystemBase {
+  // Tracks how the encoder position changes
+  private EncoderPairChange encoderChangeTracker;
+  // Where are we from start, in meters
+  private Translation2d translation = new Translation2d();
+  // Orientation change from start
+  private Rotation2d rotation = new Rotation2d();
+
+  public Odometry( EncoderPairSource encoderSource )
+  {
+    encoderChangeTracker = new EncoderPairChange( encoderSource );
+  }
+
+  /**
+   * Use left and right encoder data to estimate the robot's odometry
+   */
+  @Override
+  public void periodic() {  
+
+    final EncoderPair d = encoderChangeTracker.getChange();
+
+    if ( d.getMag() < .01 ) { return; }
+
+    // See https://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-186-mobile-autonomous-systems-laboratory-january-iap-2005/study-materials/odomtutorial.pdf
+    // for details about the math.
+
+    final double dBaseline = 17.0;   // Measured + experimental
+    final double phi = (d.getRight() - d.getLeft() ) / dBaseline;
+    final double dCenter = ( d.getLeft() + d.getRight() ) / 2.0;
+
+    final Rotation2d deltaRotation = new Rotation2d( phi );
+    final Translation2d deltaTranslation = new Translation2d( dCenter, 0.0 ).rotateBy( rotation );
+    translation = translation.plus( deltaTranslation );
+    rotation = rotation.plus( deltaRotation );
+
+    return;
+  }
+
+  public Pose2d getPoseMeters() {
+    // "Clone" so we don't leak a reference to our internal data
+    return new Pose2d( 
+      new Translation2d( translation.getX() / 100.0, translation.getY() / 100.0 ),
+      new Rotation2d( rotation.getRadians() ) );
+  }
+}


### PR DESCRIPTION
Move odometry out of the drive controller.  For separation of concerns reasons and to align with First libraries.
